### PR TITLE
Add default validate options

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -1,10 +1,14 @@
-const curry = require('ramda/src/curry')
-const flip  = require('ramda/src/flip')
-const Joi   = require('joi')
+const curryN = require('ramda/src/curryN')
+const Joi    = require('joi')
 
 const promisify = require('./promisify')
 
-// validate : Schema -> a -> Promise a
-const validate = flip(promisify(Joi.validate, Joi))
+const defaults = { abortEarly: false }
 
-module.exports = curry(validate)
+const _validate = promisify(Joi.validate, Joi)
+
+// validate : Schema -> a -> Promise a
+const validate = (schema, x, opts=defaults) =>
+  _validate(x, schema, opts)
+
+module.exports = curryN(2, validate)

--- a/test/validate.js
+++ b/test/validate.js
@@ -8,8 +8,9 @@ const schema = Joi.object({
   foo: Joi.string().required()
 })
 
-const good = { foo: 'bar' }
-const bad  = { foo: 12345 }
+const good  = { foo: 'bar' }
+const bad   = { foo: 12345 }
+const extra = { foo: 'bar', bar: '123' }
 
 describe('validate', () => {
   const res = property()
@@ -33,5 +34,15 @@ describe('validate', () => {
       expect(res()).to.be.a('Error')
       expect(res().isJoi).to.be.true
     })
+  })
+
+  describe('with custom options', () => {
+    beforeEach(() =>
+      validate(schema, extra, { stripUnknown: true }).then(res)
+    )
+
+    it('respects those options', () =>
+      expect(res()).to.eql({ foo: 'bar' })
+    )
   })
 })


### PR DESCRIPTION
![dilbert options](https://fmdm.files.wordpress.com/2007/10/stockoption.JPG)

Because `abortEarly: false` is a nice thing to have by default.