### PR TITLE
`mapP` over objects

### DIFF
--- a/src/mapP.js
+++ b/src/mapP.js
@@ -1,8 +1,30 @@
 const curry = require('ramda/src/curry')
 const map   = require('ramda/src/map')
 
-// mapP :: Functor f => (a -> Promise b) -> f a -> Promise f b
-const mapP = (f, list) =>
+const mapArrayP = (f, list) =>
   Promise.all(map(f, list))
+
+const mapObjectP = (f, list) => {
+  const result = {}
+  const promises = []
+
+  for (const key in list) {
+    const p = f(list[key]).then(val => { result[key] = val })
+    promises.push(p)
+  }
+
+  return Promise.all(promises).then(() => result)
+}
+
+// mapP :: Functor f => (a -> Promise b) -> f a -> Promise f b
+const mapP = (f, list) => {
+  switch (Object.prototype.toString.call(list)) {
+    case '[object Object]':
+      return mapObjectP(f, list)
+
+    default:
+      return mapArrayP(f, list)
+  }
+}
 
 module.exports = curry(mapP)

--- a/test/mapP.js
+++ b/test/mapP.js
@@ -7,11 +7,23 @@ const { mapP } = require('..')
 describe('mapP', () => {
   const res = property()
 
-  beforeEach(() =>
-    mapP(add(1), [ 1, 2, 3 ]).then(res)
-  )
+  context('an array argument', () => {
+    beforeEach(() =>
+      mapP(add(1), [ 1, 2, 3 ]).then(res)
+    )
 
-  it('maps over a list with an async function', () =>
-    expect(res()).to.eql([ 2, 3, 4 ])
-  )
+    it('maps over a list with an async function', () =>
+      expect(res()).to.eql([ 2, 3, 4 ])
+    )
+  })
+
+  context('an object argument', () => {
+    beforeEach(() =>
+      mapP(add(1), { foo: 1, bar: 2, baz: 3 }).then(res)
+    )
+
+    it('maps over a list with an async function', () =>
+      expect(res()).to.eql({ foo: 2, bar: 3, baz: 4 })
+    )
+  })
 })


### PR DESCRIPTION
Like ramda, allow `mapP` to accept an object as a parameter & map over its values with an async function.