### PR TITLE
Support n-ary assemble

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,8 +3,8 @@
 | Function | Signature |
 | -------- | --------- |
 | [`all`](#all) | `[Promise a] -> Promise [a]` |
-| [`assemble`](#assemble) | `{ k: (v -> v) } -> v -> { k: v }` |
-| [`assembleP`](#assemblep) | `{ k: (v -> Promise v) } -> v -> Promise { k: v }` |
+| [`assemble`](#assemble) | `{ k: ((...v) -> v) } -> (...v) -> { k: v }` |
+| [`assembleP`](#assemblep) | `{ k: ((...v) -> Promise v) } -> (...v) -> Promise { k: v }` |
 | [`assocWith`](#assocwith) | `String -> ({ k: v } -> a) -> { k: v } -> { k: v }` |
 | [`assocWithP`](#assocwithp) | `String -> ({ k: v } -> Promise a) -> { k: v } -> Promise { k: v }` |
 | [`backoff`](#backoff) | `{ k: v } -> (a... -> Promise b) -> a... -> Promise b` |

--- a/src/assemble.js
+++ b/src/assemble.js
@@ -1,18 +1,18 @@
-const curry = require('ramda/src/curry')
-const map   = require('ramda/src/map')
+const curryN = require('ramda/src/curryN')
+const map    = require('ramda/src/map')
 
-// assemble :: { k: (v -> v) } -> v -> { k: v }
-const assemble = (xfrms, x) => {
+// assemble :: { k: ((...v) -> v) } -> (...v) -> { k: v }
+const assemble = (xfrms, ...x) => {
   const transform = xfrm => {
     const type = typeof xfrm
     return type === 'function'
-      ? xfrm(x)
+      ? xfrm(...x)
       : xfrm && type === 'object'
-        ? assemble(xfrm, x)
+        ? assemble(xfrm, ...x)
         : xfrm
   }
 
   return map(transform, xfrms)
 }
 
-module.exports = curry(assemble)
+module.exports = curryN(2, assemble)

--- a/src/assembleP.js
+++ b/src/assembleP.js
@@ -1,13 +1,14 @@
 const always    = require('ramda/src/always')
-const curry     = require('ramda/src/curry')
+const apply     = require('ramda/src/apply')
+const curryN    = require('ramda/src/curryN')
 const fromPairs = require('ramda/src/fromPairs')
 const pair      = require('ramda/src/pair')
 const toPairs   = require('ramda/src/toPairs')
 
 const mapP = require('./mapP')
 
-// assembleP :: { k: (v -> Promise v) } -> v -> Promise { k: v }
-const assembleP = (xfrms, x) => {
+// assembleP :: { k: ((...v) -> Promise v) } -> (...v) -> Promise { k: v }
+const assembleP = (xfrms, ...x) => {
   const transform = ([ key, xfrm ]) => {
     const type = typeof xfrm
 
@@ -18,7 +19,7 @@ const assembleP = (xfrms, x) => {
         : always(xfrm)
 
     return Promise.resolve(x)
-      .then(xfrm)
+      .then(apply(xfrm))
       .then(pair(key))
   }
 
@@ -27,4 +28,4 @@ const assembleP = (xfrms, x) => {
     .then(fromPairs)
 }
 
-const _assembleP = module.exports = curry(assembleP)
+const _assembleP = module.exports = curryN(2, assembleP)

--- a/test/assemble.js
+++ b/test/assemble.js
@@ -4,19 +4,49 @@ const { expect } = require('chai')
 const { assemble } = require('..')
 
 describe('assemble', () => {
-  const xfrms = {
-    foo: add(1),
-    bar: {
-      baz: add(2)
-    },
-    bat: 1
-  }
+  describe('unary', () => {
+    const xfrms = {
+      foo: add(1),
+      bar: {
+        baz: add(2)
+      },
+      bat: 1
+    }
 
-  it('assembles the result of multiple transforms into a new object', () =>
-    expect(assemble(xfrms, 1)).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
-  )
+    it('assembles the result of multiple transforms into a new object', () =>
+      expect(assemble(xfrms, 1)).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
+    )
 
-  it('is curried', () =>
-    expect(assemble(xfrms)(1)).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
-  )
+    it('is curried', () =>
+      expect(assemble(xfrms)(1)).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
+    )
+  })
+
+  describe('n-ary', () => {
+    const sjoin = glue => (...params) => params.join(glue)
+
+    const xfrms = {
+      foo: sjoin(','),
+      bar: {
+        baz: sjoin('|'),
+      },
+      bat: 1
+    }
+
+    it('assembles the result of multiple transforms into a new object', () =>
+      expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      })
+    )
+
+    it('is curried', () =>
+      expect(assemble(xfrms)('one', 'two', 'three')).to.eql({
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      })
+    )
+  })
 })

--- a/test/assembleP.js
+++ b/test/assembleP.js
@@ -20,7 +20,7 @@ describe('assembleP', () => {
     )
   })
 
-  describe('unary', () => {
+  describe('n-ary', () => {
     const sjoin = glue => (...params) => Promise.resolve(params.join(glue))
 
     const assembly = assembleP({

--- a/test/assembleP.js
+++ b/test/assembleP.js
@@ -4,16 +4,45 @@ const property   = require('prop-factory')
 const { add, mult } = require('./lib/async')
 const { assembleP } = require('..')
 
-const assembly = assembleP({ foo: add(1), bar: { baz: mult(3) }, bat: 1 })
+
 
 describe('assembleP', () => {
-  const res = property()
+  describe('unary', () => {
+    const assembly = assembleP({ foo: add(1), bar: { baz: mult(3) }, bat: 1 })
+    const res = property()
 
-  beforeEach(() =>
-    assembly(1).then(res)
-  )
+    beforeEach(() =>
+      assembly(1).then(res)
+    )
 
-  it('assembles the result of async transforms into a new object', () =>
-    expect(res()).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
-  )
+    it('assembles the result of async transforms into a new object', () =>
+      expect(res()).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
+    )
+  })
+
+  describe('unary', () => {
+    const sjoin = glue => (...params) => Promise.resolve(params.join(glue))
+
+    const assembly = assembleP({
+      foo: sjoin(','),
+      bar: {
+        baz: sjoin('|'),
+      },
+      bat: 1
+    })
+
+    const res = property()
+
+    beforeEach(() =>
+      assembly('one', 'two', 'three').then(res)
+    )
+
+    it('assembles the result of async transforms into a new object', () =>
+      expect(res()).to.eql({
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      })
+    )
+  })
 })


### PR DESCRIPTION
Allow `assemble` & `assembleP` to support one or more arguments. Match the behavior of `converge` & `juxt`. Mostly for use in redux selectors.