### PR TITLE
fix assocWith & assocWithP currying

### DIFF
--- a/src/assocWith.js
+++ b/src/assocWith.js
@@ -4,7 +4,7 @@ const assoc    = require('ramda/src/assoc')
 const identity = require('ramda/src/identity')
 
 // assocWith :: String -> ({ k: v } -> a) -> { k: v } -> { k: v }
-const assocWith = (key, fn) =>
-  converge(assoc(key), [fn, identity])
+const assocWith = (key, fn, obj) =>
+  converge(assoc(key), [fn, identity])(obj)
 
 module.exports = curry(assocWith)

--- a/src/assocWithP.js
+++ b/src/assocWithP.js
@@ -4,7 +4,7 @@ const identity  = require('ramda/src/identity')
 const convergeP = require('./convergeP')
 
 // assocWithP :: String -> ({ k: v } -> Promise a) -> Promise { k: v } -> Promise { k: v }
-const assocWithP = (key, fn) =>
-  convergeP(assoc(key), [fn, identity])
+const assocWithP = (key, fn, obj) =>
+  convergeP(assoc(key), [fn, identity])(obj)
 
 module.exports = curry(assocWithP)

--- a/test/assocWith.js
+++ b/test/assocWith.js
@@ -5,10 +5,20 @@ const { assocWith } = require('..')
 const concatBarToFoo = obj =>
   obj.foo + 'bar'
 
-const doIt = assocWith('baz', concatBarToFoo)
-
 describe('assocWith', () => {
-  it('sets the foo property to the result of the function', () =>
-    expect(doIt({ foo: 'foo' })).to.eql({ foo: 'foo', baz: 'foobar' })
-  )
+  context('when partially applied', () => {
+    it('sets the foo property to the result of the function', () =>
+      expect(
+        assocWith('baz', concatBarToFoo)({ foo: 'foo' })
+      ).to.eql({ foo: 'foo', baz: 'foobar' })
+    )
+  })
+
+  context('when all arguments provided', () => {
+    it('sets the foo property to the result of the function', () =>
+      expect(
+        assocWith('baz', concatBarToFoo, { foo: 'foo' })
+      ).to.eql({ foo: 'foo', baz: 'foobar' })
+    )
+  })
 })

--- a/test/assocWithP.js
+++ b/test/assocWithP.js
@@ -6,16 +6,28 @@ const { assocWithP } = require('..')
 const concatBarToFoo = obj =>
   Promise.resolve(obj.foo + 'bar')
 
-const doIt = assocWithP('baz', concatBarToFoo)
-
 describe('assocWith', () => {
-  const res = property()
+  context('when partially applied', () => {
+    const res = property()
 
-  beforeEach(() =>
-    doIt({ foo: 'foo' }).then(res)
-  )
+    beforeEach(() =>
+      assocWithP('baz', concatBarToFoo)({ foo: 'foo' }).then(res)
+    )
 
-  it('sets the foo property to the result of the function', () =>
-    expect(res()).to.eql({ foo: 'foo', baz: 'foobar' })
-  )
+    it('sets the foo property to the result of the function', () =>
+      expect(res()).to.eql({ foo: 'foo', baz: 'foobar' })
+    )
+  })
+
+  context('when all arguments provided', () => {
+    const res = property()
+
+    beforeEach(() =>
+      assocWithP('baz', concatBarToFoo, { foo: 'foo' }).then(res)
+    )
+
+    it('sets the foo property to the result of the function', () =>
+      expect(res()).to.eql({ foo: 'foo', baz: 'foobar' })
+    )
+  })
 })


### PR DESCRIPTION
Fixes #19 

The docs specify that the following should work, but I believe they currently do not, for they currently return functions:
```js
assocWith('foo', always('bar'), {}) //=> { foo: 'bar' }
assocWithP('foo', always(Promise.resolve('bar'), {})) //=> Promise { foo: 'bar' }
```
This is because the third argument is being lost, as the functions themselves only take in 2 arguments and then the return value accepts another argument. Thus,
```js
// currently, this works
assocWith('foo', always('bar'))({}) //=> { foo: 'bar' }

// but this does not
assocWith('foo', always('bar'), {}) //=> Function
```
This fix for these two functions makes the original function accept the correct number of arguments to eventually be curried and adjusts the function body appropriately.