### PR TITLE
Return correct function length with assemble/P

### DIFF
--- a/src/assemble.js
+++ b/src/assemble.js
@@ -1,5 +1,5 @@
-const curryN = require('ramda/src/curryN')
 const map    = require('ramda/src/map')
+const doAssemble = require('./lib/doAssemble')
 
 // assemble :: { k: ((...v) -> v) } -> (...v) -> { k: v }
 const assemble = (xfrms, ...x) => {
@@ -15,4 +15,4 @@ const assemble = (xfrms, ...x) => {
   return map(transform, xfrms)
 }
 
-module.exports = curryN(2, assemble)
+module.exports = doAssemble(assemble)

--- a/src/assembleP.js
+++ b/src/assembleP.js
@@ -5,6 +5,7 @@ const fromPairs = require('ramda/src/fromPairs')
 const pair      = require('ramda/src/pair')
 const toPairs   = require('ramda/src/toPairs')
 
+const doAssemble = require('./lib/doAssemble')
 const mapP = require('./mapP')
 
 // assembleP :: { k: ((...v) -> Promise v) } -> (...v) -> Promise { k: v }
@@ -28,4 +29,6 @@ const assembleP = (xfrms, ...x) => {
     .then(fromPairs)
 }
 
-const _assembleP = module.exports = curryN(2, assembleP)
+const _assembleP = curryN(2, assembleP)
+
+module.exports = doAssemble(assembleP)

--- a/src/lib/doAssemble.js
+++ b/src/lib/doAssemble.js
@@ -11,7 +11,7 @@ const values    = require('ramda/src/values')
 const isTypeOf = curry((type, x) => typeof x === type)
 
 const getAssembleLength = xfrms =>
-  transduce(map(getLength), Math.max, 1, values(xfrms))
+  transduce(map(getLength), Math.max, 0, values(xfrms))
 
 const getLength = cond([
   [ isTypeOf('object'),   getAssembleLength ],
@@ -20,8 +20,16 @@ const getLength = cond([
 ])
 
 const doAssemble = (assemble, xfrms, ...x) => {
-  const fn = curryN(getAssembleLength(xfrms) + 1, assemble)(xfrms)
-  return x.length === 0 ? fn : fn(...x)
+  const len = getAssembleLength(xfrms)
+  const fn = curryN(len + 1, assemble)
+  if (x.length === 0) {
+    if (len === 0) {
+      // explicity return a function with arity 0 that will spread args
+      return (...y) => fn(xfrms, ...y)
+    }
+    return fn(xfrms)
+  }
+  return fn(xfrms, ...x)
 }
 
 module.exports = curry(doAssemble)

--- a/src/lib/doAssemble.js
+++ b/src/lib/doAssemble.js
@@ -19,9 +19,9 @@ const getLength = cond([
   [ T,                    always(0)         ],
 ])
 
-const doAssemble = curry((assemble, xfrms, ...x) => {
+const doAssemble = (assemble, xfrms, ...x) => {
   const fn = curryN(getAssembleLength(xfrms) + 1, assemble)(xfrms)
   return x.length === 0 ? fn : fn(...x)
-})
+}
 
-module.exports = doAssemble
+module.exports = curry(doAssemble)

--- a/src/lib/doAssemble.js
+++ b/src/lib/doAssemble.js
@@ -6,11 +6,12 @@ const length    = require('ramda/src/length')
 const map       = require('ramda/src/map')
 const T         = require('ramda/src/T')
 const transduce = require('ramda/src/transduce')
+const values    = require('ramda/src/values')
 
 const isTypeOf = curry((type, x) => typeof x === type)
 
 const getAssembleLength = xfrms =>
-  transduce(map(getLength), Math.max, 1, Object.values(xfrms))
+  transduce(map(getLength), Math.max, 1, values(xfrms))
 
 const getLength = cond([
   [ isTypeOf('object'),   getAssembleLength ],

--- a/src/lib/doAssemble.js
+++ b/src/lib/doAssemble.js
@@ -1,0 +1,26 @@
+const always    = require('ramda/src/always')
+const cond      = require('ramda/src/cond')
+const curry     = require('ramda/src/curry')
+const curryN    = require('ramda/src/curryN')
+const length    = require('ramda/src/length')
+const map       = require('ramda/src/map')
+const T         = require('ramda/src/T')
+const transduce = require('ramda/src/transduce')
+
+const isTypeOf = curry((type, x) => typeof x === type)
+
+const getAssembleLength = xfrms =>
+  transduce(map(getLength), Math.max, 1, Object.values(xfrms))
+
+const getLength = cond([
+  [ isTypeOf('object'),   getAssembleLength ],
+  [ isTypeOf('function'), length            ],
+  [ T,                    always(0)         ],
+])
+
+const doAssemble = curry((assemble, xfrms, ...x) => {
+  const fn = curryN(getAssembleLength(xfrms) + 1, assemble)(xfrms)
+  return x.length === 0 ? fn : fn(...x)
+})
+
+module.exports = doAssemble

--- a/test/assemble.js
+++ b/test/assemble.js
@@ -23,30 +23,35 @@ describe('assemble', () => {
   })
 
   describe('n-ary', () => {
-    const sjoin = glue => (...params) => params.join(glue)
-
     const xfrms = {
-      foo: sjoin(','),
+      foo: (one, two) => [ one, two ].join(','),
       bar: {
-        baz: sjoin('|'),
+        baz: (one, two, three) => [ one, two, three ].join('|'),
       },
       bat: 1
     }
 
     it('assembles the result of multiple transforms into a new object', () =>
       expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
-        foo: 'one,two,three',
+        foo: 'one,two',
         bar: { baz: 'one|two|three' },
         bat: 1,
       })
     )
 
-    it('is curried', () =>
-      expect(assemble(xfrms)('one', 'two', 'three')).to.eql({
-        foo: 'one,two,three',
+    it('is curried', () => {
+      const expectation = {
+        foo: 'one,two',
         bar: { baz: 'one|two|three' },
         bat: 1,
-      })
-    )
+      }
+      expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
+      expect(assemble(xfrms)('one')('two', 'three')).to.eql(expectation)
+      expect(assemble(xfrms)('one')('two')('three')).to.eql(expectation)
+    })
+
+    it('returns max function length', () => {
+      expect(assemble(xfrms).length).to.equal(3)
+    })
   })
 })

--- a/test/assemble.js
+++ b/test/assemble.js
@@ -54,4 +54,35 @@ describe('assemble', () => {
       expect(assemble(xfrms).length).to.equal(3)
     })
   })
+
+  describe('0-ary', () => {
+    const xfrms = {
+      foo: (...params) => params.join(','),
+      bar: {
+        baz: (...params) => params.join('|'),
+      },
+      bat: 1
+    }
+
+    it('assembles the result of multiple transforms into a new object', () =>
+      expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      })
+    )
+
+    it('is curried', () => {
+      const expectation = {
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      }
+      expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
+    })
+
+    it('returns max function length', () => {
+      expect(assemble(xfrms).length).to.equal(0)
+    })
+  })
 })

--- a/test/assembleP.js
+++ b/test/assembleP.js
@@ -47,4 +47,32 @@ describe('assembleP', () => {
       expect(assembly.length).to.equal(3)
     })
   })
+
+  describe('0-ary', () => {
+    const assembly = assembleP({
+      foo: (...params) => Promise.resolve(params.join(',')),
+      bar: {
+        baz: (...params) => Promise.resolve(params.join('|')),
+      },
+      bat: 1
+    })
+
+    const res = property()
+
+    beforeEach(() =>
+      assembly('one', 'two', 'three').then(res)
+    )
+
+    it('assembles the result of async transforms into a new object', () =>
+      expect(res()).to.eql({
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      })
+    )
+
+    it('returns max function length', () => {
+      expect(assembly.length).to.equal(0)
+    })
+  })
 })

--- a/test/assembleP.js
+++ b/test/assembleP.js
@@ -21,12 +21,10 @@ describe('assembleP', () => {
   })
 
   describe('n-ary', () => {
-    const sjoin = glue => (...params) => Promise.resolve(params.join(glue))
-
     const assembly = assembleP({
-      foo: sjoin(','),
+      foo: (one, two) => Promise.resolve([ one, two ].join(',')),
       bar: {
-        baz: sjoin('|'),
+        baz: (one, two, three) => Promise.resolve([ one, two, three ].join('|')),
       },
       bat: 1
     })
@@ -39,10 +37,14 @@ describe('assembleP', () => {
 
     it('assembles the result of async transforms into a new object', () =>
       expect(res()).to.eql({
-        foo: 'one,two,three',
+        foo: 'one,two',
         bar: { baz: 'one|two|three' },
         bat: 1,
       })
     )
+
+    it('returns max function length', () => {
+      expect(assembly.length).to.equal(3)
+    })
   })
 })


### PR DESCRIPTION
**Closes #17**

Like, `converge`, ensure that the resulting function returned by `assemble` & `assembleP`:
* Has the same arity of the longest branching function ~with a minimum arity of 1 (unlike `converge`)~ _**Update:** Changed to minimum arity of 0._
* Is auto-curried