### PR TITLE
Support arrays in assembleP

### DIFF
--- a/src/assembleP.js
+++ b/src/assembleP.js
@@ -1,34 +1,46 @@
-const always    = require('ramda/src/always')
-const apply     = require('ramda/src/apply')
-const curryN    = require('ramda/src/curryN')
+const always = require('ramda/src/always')
+const apply = require('ramda/src/apply')
+const compose = require('ramda/src/compose')
+const cond = require('ramda/src/cond')
+const curryN = require('ramda/src/curryN')
 const fromPairs = require('ramda/src/fromPairs')
-const pair      = require('ramda/src/pair')
-const toPairs   = require('ramda/src/toPairs')
+const identity = require('ramda/src/identity')
+const is = require('ramda/src/is')
+const map = require('ramda/src/map')
+const pair = require('ramda/src/pair')
+const T = require('ramda/src/T')
+const toPairs = require('ramda/src/toPairs')
 
 const doAssemble = require('./lib/doAssemble')
+const juxtP = require('./juxtP')
 const mapP = require('./mapP')
 
 // assembleP :: { k: ((...v) -> Promise v) } -> (...v) -> Promise { k: v }
-const assembleP = (xfrms, ...x) => {
-  const transform = ([ key, xfrm ]) => {
-    const type = typeof xfrm
+const assembleP = (xfrms, ...args) =>
+  apply(handle(xfrms), args)
 
-    xfrm = type === 'function'
-      ? xfrm
-      : xfrm && type === 'object'
-        ? _assembleP(xfrm)
-        : always(xfrm)
+const _assembleP = curryN(2, assembleP)
 
-    return Promise.resolve(x)
-      .then(apply(xfrm))
+const _assembleArrayP =
+  compose(juxtP, map(_assembleP))
+
+const _assembleObjP = xfrms => (...args) => {
+  const transformObj = ([ key, xfrm ]) =>
+    Promise.resolve(args)
+      .then(apply(handle(xfrm)))
       .then(pair(key))
-  }
 
   return Promise.resolve(toPairs(xfrms))
-    .then(mapP(transform))
+    .then(mapP(transformObj))
     .then(fromPairs)
 }
 
-const _assembleP = curryN(2, assembleP)
+const handle =
+  cond([
+    [ is(Function), identity ],
+    [ is(Array), _assembleArrayP ],
+    [ is(Object), _assembleObjP ],
+    [ T, always ]
+  ])
 
 module.exports = doAssemble(assembleP)

--- a/test/assemble.js
+++ b/test/assemble.js
@@ -6,19 +6,17 @@ const { assemble } = require('..')
 describe('assemble', () => {
   describe('unary', () => {
     const xfrms = {
-      foo: add(1),
-      bar: {
-        baz: add(2)
-      },
+      foo: [[ add(1) ]],
+      bar: [{ baz: add(2) }],
       bat: 1
     }
 
     it('assembles the result of multiple transforms into a new object', () =>
-      expect(assemble(xfrms, 1)).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
+      expect(assemble(xfrms, 1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
     )
 
     it('is curried', () =>
-      expect(assemble(xfrms)(1)).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
+      expect(assemble(xfrms)(1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
     )
   })
 
@@ -85,4 +83,6 @@ describe('assemble', () => {
       expect(assemble(xfrms).length).to.equal(0)
     })
   })
+
+
 })

--- a/test/assembleP.js
+++ b/test/assembleP.js
@@ -8,7 +8,12 @@ const { assembleP } = require('..')
 
 describe('assembleP', () => {
   describe('unary', () => {
-    const assembly = assembleP({ foo: add(1), bar: { baz: mult(3) }, bat: 1 })
+    const assembly = assembleP({
+      foo: [[ add(1) ]],
+      bar: [{ baz: mult(3) }],
+      bat: 1
+    })
+
     const res = property()
 
     beforeEach(() =>
@@ -16,7 +21,7 @@ describe('assembleP', () => {
     )
 
     it('assembles the result of async transforms into a new object', () =>
-      expect(res()).to.eql({ foo: 2, bar: { baz: 3 }, bat: 1 })
+      expect(res()).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
     )
   })
 

--- a/test/assembleP.js
+++ b/test/assembleP.js
@@ -27,10 +27,10 @@ describe('assembleP', () => {
 
   describe('n-ary', () => {
     const assembly = assembleP({
-      foo: (one, two) => Promise.resolve([ one, two ].join(',')),
-      bar: {
+      foo: [[ (one, two) => Promise.resolve([ one, two ].join(',')) ]],
+      bar: [{
         baz: (one, two, three) => Promise.resolve([ one, two, three ].join('|')),
-      },
+      }],
       bat: 1
     })
 
@@ -42,8 +42,8 @@ describe('assembleP', () => {
 
     it('assembles the result of async transforms into a new object', () =>
       expect(res()).to.eql({
-        foo: 'one,two',
-        bar: { baz: 'one|two|three' },
+        foo: [[ 'one,two' ]],
+        bar: [{ baz: 'one|two|three' }],
         bat: 1,
       })
     )
@@ -55,10 +55,10 @@ describe('assembleP', () => {
 
   describe('0-ary', () => {
     const assembly = assembleP({
-      foo: (...params) => Promise.resolve(params.join(',')),
-      bar: {
+      foo: [[ (...params) => Promise.resolve(params.join(',')) ]],
+      bar: [{
         baz: (...params) => Promise.resolve(params.join('|')),
-      },
+      }],
       bat: 1
     })
 
@@ -70,8 +70,8 @@ describe('assembleP', () => {
 
     it('assembles the result of async transforms into a new object', () =>
       expect(res()).to.eql({
-        foo: 'one,two,three',
-        bar: { baz: 'one|two|three' },
+        foo: [[ 'one,two,three' ]],
+        bar: [{ baz: 'one|two|three' }],
         bat: 1,
       })
     )


### PR DESCRIPTION
![dilbert](http://robohub.org/wp-content/uploads/2015/12/204b623f-8d07-414f-a759-6bad292f2a09.jpg)

Because I wanted to do something like this, which wouldn't work before:

```js
const authorizer =
  assembleP({
    principalId: prop('authorizationToken'),
    policyDocument: {
      Version: '2012-10-17',
      Statement: [
        {
          Action: 'execute-api:Invoke',
          Effect: getEffect,
          Resource: prop('methodArn')
        }
      ]
    }
  })
```