### PR TITLE
Use uncurryN to handle partial application and the providing of all arguments, as well

### DIFF
--- a/src/assocWith.js
+++ b/src/assocWith.js
@@ -1,10 +1,10 @@
-const converge = require('ramda/src/converge')
-const curry    = require('ramda/src/curry')
 const assoc    = require('ramda/src/assoc')
+const converge = require('ramda/src/converge')
 const identity = require('ramda/src/identity')
+const uncurryN = require('ramda/src/uncurryN')
 
 // assocWith :: String -> ({ k: v } -> a) -> { k: v } -> { k: v }
-const assocWith = (key, fn, obj) =>
-  converge(assoc(key), [fn, identity])(obj)
+const assocWith = (key, fn) =>
+  converge(assoc(key), [fn, identity])
 
-module.exports = curry(assocWith)
+module.exports = uncurryN(3, assocWith)

--- a/src/assocWithP.js
+++ b/src/assocWithP.js
@@ -1,10 +1,11 @@
-const curry     = require('ramda/src/curry')
 const assoc     = require('ramda/src/assoc')
 const identity  = require('ramda/src/identity')
+const uncurryN  = require('ramda/src/uncurryN')
+
 const convergeP = require('./convergeP')
 
 // assocWithP :: String -> ({ k: v } -> Promise a) -> Promise { k: v } -> Promise { k: v }
-const assocWithP = (key, fn, obj) =>
-  convergeP(assoc(key), [fn, identity])(obj)
+const assocWithP = (key, fn) =>
+  convergeP(assoc(key), [fn, identity])
 
-module.exports = curry(assocWithP)
+module.exports = uncurryN(3, assocWithP)

--- a/src/combineAll.js
+++ b/src/combineAll.js
@@ -2,7 +2,10 @@ const compose  = require('ramda/src/compose')
 const identity = require('ramda/src/identity')
 const juxt     = require('ramda/src/juxt')
 const mergeAll = require('ramda/src/mergeAll')
+const uncurryN = require('ramda/src/uncurryN')
 
 // combineAll :: [({ k: v }, ...) -> { k: v }] -> ({ k: v }, ...) -> { k: v }
-module.exports = fns =>
+const combineAll = fns =>
   compose(mergeAll, juxt([ identity, ...fns ]))
+
+module.exports = uncurryN(2, combineAll)

--- a/src/combineAllP.js
+++ b/src/combineAllP.js
@@ -1,9 +1,12 @@
 const composeP = require('ramda/src/composeP')
 const identity = require('ramda/src/identity')
 const mergeAll = require('ramda/src/mergeAll')
+const uncurryN = require('ramda/src/uncurryN')
 
 const juxtP    = require('./juxtP')
 
 // combineAllP :: [({ k: v }, ...) -> Promise { k: v }] -> ({ k: v }, ...) -> Promise { k: v }
-module.exports = fns =>
+const combineAllP = fns =>
   composeP(mergeAll, juxtP([ identity, ...fns ]))
+
+module.exports = uncurryN(2, combineAllP)

--- a/src/combineWith.js
+++ b/src/combineWith.js
@@ -1,9 +1,9 @@
 const converge = require('ramda/src/converge')
-const curry = require('ramda/src/curry')
 const identity = require('ramda/src/identity')
+const uncurryN = require('ramda/src/uncurryN')
 
 // combineWith :: (c -> b -> d) (a -> b) -> c -> d
 const combineWith = (mf, f) =>
   converge(mf, [ identity, f ])
 
-module.exports = curry(combineWith)
+module.exports = uncurryN(3, combineWith)

--- a/src/combineWithP.js
+++ b/src/combineWithP.js
@@ -1,5 +1,5 @@
-const curry    = require('ramda/src/curry')
 const identity = require('ramda/src/identity')
+const uncurryN = require('ramda/src/uncurryN')
 
 const convergeP = require('./convergeP')
 
@@ -7,4 +7,4 @@ const convergeP = require('./convergeP')
 const combineWithP = (mf, f) =>
   convergeP(mf, [ identity, f ])
 
-module.exports = curry(combineWithP)
+module.exports = uncurryN(3, combineWithP)

--- a/src/evolveP.js
+++ b/src/evolveP.js
@@ -1,13 +1,16 @@
-const curry     = require('ramda/src/curry')
+const compose   = require('ramda/src/compose')
+const composeP  = require('ramda/src/composeP')
 const fromPairs = require('ramda/src/fromPairs')
 const identity  = require('ramda/src/identity')
 const pair      = require('ramda/src/pair')
 const toPairs   = require('ramda/src/toPairs')
+const uncurryN  = require('ramda/src/uncurryN')
 
-const mapP = require('./mapP')
+const mapP      = require('./mapP')
+const resolve   = require('./resolve')
 
 // evolveP :: { k: (v -> Promise v) } -> { k: v } -> Promise { k: v }
-const evolveP = (transforms, obj) => {
+const evolveP = transforms => {
   const transform = ([ key, val ]) => {
     let xfrm = transforms[key]
     const type = typeof xfrm
@@ -23,9 +26,10 @@ const evolveP = (transforms, obj) => {
       .then(pair(key))
   }
 
-  return Promise.resolve(toPairs(obj))
-    .then(mapP(transform))
-    .then(fromPairs)
+  return compose(
+    composeP(fromPairs, mapP(transform), resolve),
+    toPairs
+  )
 }
 
-const _evolveP = module.exports = curry(evolveP)
+const _evolveP = module.exports = uncurryN(2, evolveP)

--- a/src/evolveP.js
+++ b/src/evolveP.js
@@ -6,8 +6,7 @@ const pair      = require('ramda/src/pair')
 const toPairs   = require('ramda/src/toPairs')
 const uncurryN  = require('ramda/src/uncurryN')
 
-const mapP      = require('./mapP')
-const resolve   = require('./resolve')
+const mapP = require('./mapP')
 
 // evolveP :: { k: (v -> Promise v) } -> { k: v } -> Promise { k: v }
 const evolveP = transforms => {
@@ -26,10 +25,7 @@ const evolveP = transforms => {
       .then(pair(key))
   }
 
-  return compose(
-    composeP(fromPairs, mapP(transform), resolve),
-    toPairs
-  )
+  return compose(composeP(fromPairs, mapP(transform)), toPairs)
 }
 
 const _evolveP = module.exports = uncurryN(2, evolveP)

--- a/src/normalizeBy.js
+++ b/src/normalizeBy.js
@@ -1,13 +1,13 @@
-const assoc  = require('ramda/src/assoc')
-const curry  = require('ramda/src/curry')
-const reduce = require('ramda/src/reduce')
+const assoc    = require('ramda/src/assoc')
+const reduce   = require('ramda/src/reduce')
+const uncurryN = require('ramda/src/uncurryN')
 
 // normalizeBy :: String -> [{ k: v }] -> { v: { k: v } }
-const normalizeBy = (id, list) =>
-  reduce(putBy(id), {}, list)
+const normalizeBy = id =>
+  reduce(putBy(id), {})
 
 // putBy :: String -> ({ v: { k: v } }, { k: v }) -> { v: { k: v } }
 const putBy = id => (list, item) =>
   assoc(item[id], item, list)
 
-module.exports = curry(normalizeBy)
+module.exports = uncurryN(2, normalizeBy)

--- a/src/rename.js
+++ b/src/rename.js
@@ -1,13 +1,13 @@
 const assoc    = require('ramda/src/assoc')
 const converge = require('ramda/src/converge')
-const curry    = require('ramda/src/curry')
 const dissoc   = require('ramda/src/dissoc')
 const hasIn    = require('ramda/src/hasIn')
 const prop     = require('ramda/src/prop')
+const uncurryN = require('ramda/src/uncurryN')
 const when     = require('ramda/src/when')
 
 // rename :: String -> String -> { k: v } -> { k: v }
-const rename = (frum, to, obj) =>
-  when(hasIn(frum), converge(assoc(to), [ prop(frum), dissoc(frum) ]))(obj)
+const rename = (frum, to) =>
+  when(hasIn(frum), converge(assoc(to), [ prop(frum), dissoc(frum) ]))
 
-module.exports = curry(rename)
+module.exports = uncurryN(3, rename)

--- a/src/useWithP.js
+++ b/src/useWithP.js
@@ -1,8 +1,13 @@
-const { apply, composeP, curry, unapply, useWith } = require('ramda')
-const all = require('./all')
+const apply    = require('ramda/src/apply')
+const composeP = require('ramda/src/composeP')
+const unapply  = require('ramda/src/unapply')
+const uncurryN = require('ramda/src/uncurryN')
+const useWith  = require('ramda/src/useWith')
+
+const all      = require('./all')
 
 // useWithP :: (a -> b -> Promise c) -> [(d -> Promise a), (e -> Promise b)] -> (d -> e -> Promise c)
-const useWithP = (fn, transformers) =>
-  useWith(unapply(composeP(apply(fn), all)), transformers)
+const useWithP = fn =>
+  useWith(unapply(composeP(apply(fn), all)))
 
-module.exports = curry(useWithP)
+module.exports = uncurryN(2, useWithP)

--- a/test/assemble.js
+++ b/test/assemble.js
@@ -11,17 +11,13 @@ describe('assemble', () => {
       bat: 1
     }
 
-    context('when partially applied', () => {
-      it('assembles the result of multiple transforms into a new object', () =>
-        expect(assemble(xfrms)(1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
-      )
-    })
+    it('assembles the result of multiple transforms into a new object', () =>
+      expect(assemble(xfrms, 1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
+    )
 
-    context('when all arguments provided', () => {
-      it('assembles the result of multiple transforms into a new object', () =>
-        expect(assemble(xfrms, 1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
-      )
-    })
+    it('is curried', () =>
+      expect(assemble(xfrms)(1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
+    )
   })
 
   describe('n-ary', () => {
@@ -33,27 +29,23 @@ describe('assemble', () => {
       bat: 1
     }
 
-    context('when partially applied', () => {
-      it('assembles the result of multiple transforms into a new object', () => {
-        const expectation = {
-          foo: 'one,two',
-          bar: { baz: 'one|two|three' },
-          bat: 1,
-        }
-        expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
-        expect(assemble(xfrms)('one')('two', 'three')).to.eql(expectation)
-        expect(assemble(xfrms)('one')('two')('three')).to.eql(expectation)
+    it('assembles the result of multiple transforms into a new object', () =>
+      expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
+        foo: 'one,two',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
       })
-    })
+    )
 
-    context('when all arguments provided', () => {
-      it('assembles the result of multiple transforms into a new object', () =>
-        expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
-          foo: 'one,two',
-          bar: { baz: 'one|two|three' },
-          bat: 1,
-        })
-      )
+    it('is curried', () => {
+      const expectation = {
+        foo: 'one,two',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      }
+      expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
+      expect(assemble(xfrms)('one')('two', 'three')).to.eql(expectation)
+      expect(assemble(xfrms)('one')('two')('three')).to.eql(expectation)
     })
 
     it('returns max function length', () => {
@@ -70,25 +62,21 @@ describe('assemble', () => {
       bat: 1
     }
 
-    context('when partially applied', () => {
-      it('assembles the result of multiple transforms into a new object', () => {
-        const expectation = {
-          foo: 'one,two,three',
-          bar: { baz: 'one|two|three' },
-          bat: 1,
-        }
-        expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
+    it('assembles the result of multiple transforms into a new object', () =>
+      expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
       })
-    })
+    )
 
-    context('when all arguments provided', () => {
-      it('assembles the result of multiple transforms into a new object', () =>
-        expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
-          foo: 'one,two,three',
-          bar: { baz: 'one|two|three' },
-          bat: 1,
-        })
-      )
+    it('is curried', () => {
+      const expectation = {
+        foo: 'one,two,three',
+        bar: { baz: 'one|two|three' },
+        bat: 1,
+      }
+      expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
     })
 
     it('returns max function length', () => {

--- a/test/assemble.js
+++ b/test/assemble.js
@@ -11,13 +11,17 @@ describe('assemble', () => {
       bat: 1
     }
 
-    it('assembles the result of multiple transforms into a new object', () =>
-      expect(assemble(xfrms, 1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
-    )
+    context('when partially applied', () => {
+      it('assembles the result of multiple transforms into a new object', () =>
+        expect(assemble(xfrms)(1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
+      )
+    })
 
-    it('is curried', () =>
-      expect(assemble(xfrms)(1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
-    )
+    context('when all arguments provided', () => {
+      it('assembles the result of multiple transforms into a new object', () =>
+        expect(assemble(xfrms, 1)).to.eql({ foo: [[ 2 ]], bar: [{ baz: 3 }], bat: 1 })
+      )
+    })
   })
 
   describe('n-ary', () => {
@@ -29,23 +33,27 @@ describe('assemble', () => {
       bat: 1
     }
 
-    it('assembles the result of multiple transforms into a new object', () =>
-      expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
-        foo: 'one,two',
-        bar: { baz: 'one|two|three' },
-        bat: 1,
+    context('when partially applied', () => {
+      it('assembles the result of multiple transforms into a new object', () => {
+        const expectation = {
+          foo: 'one,two',
+          bar: { baz: 'one|two|three' },
+          bat: 1,
+        }
+        expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
+        expect(assemble(xfrms)('one')('two', 'three')).to.eql(expectation)
+        expect(assemble(xfrms)('one')('two')('three')).to.eql(expectation)
       })
-    )
+    })
 
-    it('is curried', () => {
-      const expectation = {
-        foo: 'one,two',
-        bar: { baz: 'one|two|three' },
-        bat: 1,
-      }
-      expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
-      expect(assemble(xfrms)('one')('two', 'three')).to.eql(expectation)
-      expect(assemble(xfrms)('one')('two')('three')).to.eql(expectation)
+    context('when all arguments provided', () => {
+      it('assembles the result of multiple transforms into a new object', () =>
+        expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
+          foo: 'one,two',
+          bar: { baz: 'one|two|three' },
+          bat: 1,
+        })
+      )
     })
 
     it('returns max function length', () => {
@@ -62,27 +70,29 @@ describe('assemble', () => {
       bat: 1
     }
 
-    it('assembles the result of multiple transforms into a new object', () =>
-      expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
-        foo: 'one,two,three',
-        bar: { baz: 'one|two|three' },
-        bat: 1,
+    context('when partially applied', () => {
+      it('assembles the result of multiple transforms into a new object', () => {
+        const expectation = {
+          foo: 'one,two,three',
+          bar: { baz: 'one|two|three' },
+          bat: 1,
+        }
+        expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
       })
-    )
+    })
 
-    it('is curried', () => {
-      const expectation = {
-        foo: 'one,two,three',
-        bar: { baz: 'one|two|three' },
-        bat: 1,
-      }
-      expect(assemble(xfrms)('one', 'two', 'three')).to.eql(expectation)
+    context('when all arguments provided', () => {
+      it('assembles the result of multiple transforms into a new object', () =>
+        expect(assemble(xfrms, 'one', 'two', 'three')).to.eql({
+          foo: 'one,two,three',
+          bar: { baz: 'one|two|three' },
+          bat: 1,
+        })
+      )
     })
 
     it('returns max function length', () => {
       expect(assemble(xfrms).length).to.equal(0)
     })
   })
-
-
 })

--- a/test/assocWith.js
+++ b/test/assocWith.js
@@ -6,19 +6,16 @@ const concatBarToFoo = obj =>
   obj.foo + 'bar'
 
 describe('assocWith', () => {
-  context('when partially applied', () => {
-    it('sets the foo property to the result of the function', () =>
-      expect(
-        assocWith('baz', concatBarToFoo)({ foo: 'foo' })
-      ).to.eql({ foo: 'foo', baz: 'foobar' })
-    )
-  })
+  it('sets the foo property to the result of the function', () =>
+    expect(assocWith('baz', concatBarToFoo, { foo: 'foo' }))
+      .to.eql({ foo: 'foo', baz: 'foobar' })
+  )
 
-  context('when all arguments provided', () => {
-    it('sets the foo property to the result of the function', () =>
-      expect(
-        assocWith('baz', concatBarToFoo, { foo: 'foo' })
-      ).to.eql({ foo: 'foo', baz: 'foobar' })
-    )
+  it('is curried', () => {
+    expect(assocWith('baz', concatBarToFoo)({ foo: 'foo' }))
+      .to.eql({ foo: 'foo', baz: 'foobar' })
+
+    expect(assocWith('baz')(concatBarToFoo)({ foo: 'foo' }))
+      .to.eql({ foo: 'foo', baz: 'foobar' })
   })
 })

--- a/test/assocWith.js
+++ b/test/assocWith.js
@@ -11,11 +11,20 @@ describe('assocWith', () => {
       .to.eql({ foo: 'foo', baz: 'foobar' })
   )
 
-  it('is curried', () => {
-    expect(assocWith('baz', concatBarToFoo)({ foo: 'foo' }))
-      .to.eql({ foo: 'foo', baz: 'foobar' })
+  describe('argument application', () => {
+    it('apply fn(x)(x)(x)', () =>
+      expect(assocWith('baz')(concatBarToFoo)({ foo: 'foo' }))
+        .to.eql({ foo: 'foo', baz: 'foobar' })
+    )
 
-    expect(assocWith('baz')(concatBarToFoo)({ foo: 'foo' }))
-      .to.eql({ foo: 'foo', baz: 'foobar' })
+    it('apply fn(x, x)(x)', () =>
+      expect(assocWith('baz', concatBarToFoo)({ foo: 'foo' }))
+        .to.eql({ foo: 'foo', baz: 'foobar' })
+    )
+
+    it('apply fn(x)(x, x)', () =>
+      expect(assocWith('baz')(concatBarToFoo, { foo: 'foo' }))
+        .to.eql({ foo: 'foo', baz: 'foobar' })
+    )
   })
 })

--- a/test/assocWithP.js
+++ b/test/assocWithP.js
@@ -24,5 +24,11 @@ describe('assocWithP', () => {
         expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
       })
     )
+
+    it('apply fn(x)(x, x)', () =>
+      assocWithP('baz')(concatBarToFoo, { foo: 'foo' }).then(res => {
+        expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
+      })
+    )
   })
 })

--- a/test/assocWithP.js
+++ b/test/assocWithP.js
@@ -1,33 +1,26 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 
 const { assocWithP } = require('..')
 
 const concatBarToFoo = obj =>
   Promise.resolve(obj.foo + 'bar')
 
-describe('assocWith', () => {
-  context('when partially applied', () => {
-    const res = property()
+describe('assocWithP', () => {
+  it('sets the foo property to the result of the function', () =>
+    assocWithP('baz', concatBarToFoo, { foo: 'foo' }).then(res => {
+      expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
+    })
+  )
 
-    beforeEach(() =>
-      assocWithP('baz', concatBarToFoo)({ foo: 'foo' }).then(res)
-    )
+  it('is curried, arity 1', () =>
+    assocWithP('baz', concatBarToFoo)({ foo: 'foo' }).then(res => {
+      expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
+    })
+  )
 
-    it('sets the foo property to the result of the function', () =>
-      expect(res()).to.eql({ foo: 'foo', baz: 'foobar' })
-    )
-  })
-
-  context('when all arguments provided', () => {
-    const res = property()
-
-    beforeEach(() =>
-      assocWithP('baz', concatBarToFoo, { foo: 'foo' }).then(res)
-    )
-
-    it('sets the foo property to the result of the function', () =>
-      expect(res()).to.eql({ foo: 'foo', baz: 'foobar' })
-    )
-  })
+  it('is curried, arity 2, unary', () =>
+    assocWithP('baz')(concatBarToFoo)({ foo: 'foo' }).then(res => {
+      expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
+    })
+  )
 })

--- a/test/assocWithP.js
+++ b/test/assocWithP.js
@@ -12,15 +12,17 @@ describe('assocWithP', () => {
     })
   )
 
-  it('is curried, arity 1', () =>
-    assocWithP('baz', concatBarToFoo)({ foo: 'foo' }).then(res => {
-      expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
-    })
-  )
+  describe('argument application', () => {
+    it('apply fn(x)(x)(x)', () =>
+      assocWithP('baz')(concatBarToFoo)({ foo: 'foo' }).then(res => {
+        expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
+      })
+    )
 
-  it('is curried, arity 2, unary', () =>
-    assocWithP('baz')(concatBarToFoo)({ foo: 'foo' }).then(res => {
-      expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
-    })
-  )
+    it('apply fn(x, x)(x)', () =>
+      assocWithP('baz', concatBarToFoo)({ foo: 'foo' }).then(res => {
+        expect(res).to.eql({ foo: 'foo', baz: 'foobar' })
+      })
+    )
+  })
 })

--- a/test/combine.js
+++ b/test/combine.js
@@ -5,14 +5,12 @@ const { combine } = require('..')
 
 describe('combine', () => {
   it('merges with the results of the function', () =>
-    expect(
-      combine(always({ foo: 'bar' }), { baz: 'bip' })
-    ).to.eql({ foo: 'bar', baz: 'bip' })
+    expect(combine(always({ foo: 'bar' }), { baz: 'bip' }))
+      .to.eql({ foo: 'bar', baz: 'bip' })
   )
 
   it('is curried', () =>
-    expect(
-      combine(always({ foo: 'bar' }))({ baz: 'bip' })
-    ).to.eql({ foo: 'bar', baz: 'bip' })
+    expect(combine(always({ foo: 'bar' }))({ baz: 'bip' }))
+      .to.eql({ foo: 'bar', baz: 'bip' })
   )
 })

--- a/test/combine.js
+++ b/test/combine.js
@@ -1,22 +1,22 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 const always     = require('ramda/src/always')
 
 const { combine } = require('..')
 
-const whatevs = combine(always({ foo: 'bar' }))
-
 describe('combine', () => {
-  const res = property()
+  context('when partially applied', () => {
+    it('merges with the results of the function', () =>
+      expect(
+        combine(always({ foo: 'bar' }))({ baz: 'bip' })
+      ).to.eql({ foo: 'bar', baz: 'bip' })
+    )
+  })
 
-  beforeEach(() =>
-    res(whatevs({ baz: 'bip' }))
-  )
-
-  it('merges with the results of the function', () =>
-    expect(res()).to.eql({
-      foo: 'bar',
-      baz: 'bip',
-    })
-  )
+  context('when all arguments provided', () => {
+    it('merges with the results of the function', () =>
+      expect(
+        combine(always({ foo: 'bar' }), { baz: 'bip' })
+      ).to.eql({ foo: 'bar', baz: 'bip' })
+    )
+  })
 })

--- a/test/combine.js
+++ b/test/combine.js
@@ -4,19 +4,15 @@ const always     = require('ramda/src/always')
 const { combine } = require('..')
 
 describe('combine', () => {
-  context('when partially applied', () => {
-    it('merges with the results of the function', () =>
-      expect(
-        combine(always({ foo: 'bar' }))({ baz: 'bip' })
-      ).to.eql({ foo: 'bar', baz: 'bip' })
-    )
-  })
+  it('merges with the results of the function', () =>
+    expect(
+      combine(always({ foo: 'bar' }), { baz: 'bip' })
+    ).to.eql({ foo: 'bar', baz: 'bip' })
+  )
 
-  context('when all arguments provided', () => {
-    it('merges with the results of the function', () =>
-      expect(
-        combine(always({ foo: 'bar' }), { baz: 'bip' })
-      ).to.eql({ foo: 'bar', baz: 'bip' })
-    )
-  })
+  it('is curried', () =>
+    expect(
+      combine(always({ foo: 'bar' }))({ baz: 'bip' })
+    ).to.eql({ foo: 'bar', baz: 'bip' })
+  )
 })

--- a/test/combineAll.js
+++ b/test/combineAll.js
@@ -4,25 +4,21 @@ const always     = require('ramda/src/always')
 const { combineAll } = require('..')
 
 describe('combineAll', () => {
-  context('when partially applied', () => {
-    it('combines the results of all functions', () =>
-      expect(
-        combineAll([
-          always({ foo: 1 }),
-          always({ bar: 2 }),
-        ])({ baz: 3 })
-      ).to.eql({ foo: 1, bar: 2, baz: 3 })
-    )
-  })
+  it('combines the results of all functions', () =>
+    expect(
+      combineAll([
+        always({ foo: 1 }),
+        always({ bar: 2 }),
+      ], { baz: 3 })
+    ).to.eql({ foo: 1, bar: 2, baz: 3 })
+  )
 
-  context('when all arguments provided', () => {
-    it('combines the results of all functions', () =>
-      expect(
-        combineAll([
-          always({ foo: 1 }),
-          always({ bar: 2 }),
-        ], { baz: 3 })
-      ).to.eql({ foo: 1, bar: 2, baz: 3 })
-    )
-  })
+  it('is curried', () =>
+    expect(
+      combineAll([
+        always({ foo: 1 }),
+        always({ bar: 2 }),
+      ])({ baz: 3 })
+    ).to.eql({ foo: 1, bar: 2, baz: 3 })
+  )
 })

--- a/test/combineAll.js
+++ b/test/combineAll.js
@@ -3,22 +3,19 @@ const always     = require('ramda/src/always')
 
 const { combineAll } = require('..')
 
+const actions = [
+  always({ foo: 1 }),
+  always({ bar: 2 }),
+]
+
 describe('combineAll', () => {
   it('combines the results of all functions', () =>
-    expect(
-      combineAll([
-        always({ foo: 1 }),
-        always({ bar: 2 }),
-      ], { baz: 3 })
-    ).to.eql({ foo: 1, bar: 2, baz: 3 })
+    expect(combineAll(actions, { baz: 3 }))
+      .to.eql({ foo: 1, bar: 2, baz: 3 })
   )
 
   it('is curried', () =>
-    expect(
-      combineAll([
-        always({ foo: 1 }),
-        always({ bar: 2 }),
-      ])({ baz: 3 })
-    ).to.eql({ foo: 1, bar: 2, baz: 3 })
+    expect(combineAll(actions)({ baz: 3 }))
+      .to.eql({ foo: 1, bar: 2, baz: 3 })
   )
 })

--- a/test/combineAll.js
+++ b/test/combineAll.js
@@ -1,26 +1,28 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 const always     = require('ramda/src/always')
 
 const { combineAll } = require('..')
 
-const whatevs = combineAll([
-  always({ foo: 1 }),
-  always({ bar: 2 }),
-])
-
 describe('combineAll', () => {
-  const res = property()
+  context('when partially applied', () => {
+    it('combines the results of all functions', () =>
+      expect(
+        combineAll([
+          always({ foo: 1 }),
+          always({ bar: 2 }),
+        ])({ baz: 3 })
+      ).to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+  })
 
-  beforeEach(() =>
-    res(whatevs({ baz: 3 }))
-  )
-
-  it('combines the results of all functions', () =>
-    expect(res()).to.eql({
-      foo: 1,
-      bar: 2,
-      baz: 3,
-    })
-  )
+  context('when all arguments provided', () => {
+    it('combines the results of all functions', () =>
+      expect(
+        combineAll([
+          always({ foo: 1 }),
+          always({ bar: 2 }),
+        ], { baz: 3 })
+      ).to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+  })
 })

--- a/test/combineAllP.js
+++ b/test/combineAllP.js
@@ -4,23 +4,34 @@ const always     = require('ramda/src/always')
 
 const { combineAllP } = require('..')
 
-const whatevs = combineAllP([
-  always(Promise.resolve({ foo: 1 })),
-  always(Promise.resolve({ bar: 2 })),
-])
-
 describe('combineAll', () => {
-  const res = property()
+  context('when partially applied', () => {
+    const res = property()
 
-  beforeEach(() =>
-    whatevs({ baz: 3 }).then(res)
-  )
+    beforeEach(() =>
+      combineAllP([
+        always(Promise.resolve({ foo: 1 })),
+        always(Promise.resolve({ bar: 2 })),
+      ])({ baz: 3 }).then(res)
+    )
 
-  it('combines the results of all functions', () =>
-    expect(res()).to.eql({
-      foo: 1,
-      bar: 2,
-      baz: 3,
-    })
-  )
+    it('combines the results of all functions', () =>
+      expect(res()).to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+  })
+
+  context('when all arguments provided', () => {
+    const res = property()
+
+    beforeEach(() =>
+      combineAllP([
+        always(Promise.resolve({ foo: 1 })),
+        always(Promise.resolve({ bar: 2 })),
+      ], { baz: 3 }).then(res)
+    )
+
+    it('combines the results of all functions', () =>
+      expect(res()).to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+  })
 })

--- a/test/combineAllP.js
+++ b/test/combineAllP.js
@@ -1,37 +1,23 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 const always     = require('ramda/src/always')
 
 const { combineAllP } = require('..')
 
-describe('combineAll', () => {
-  context('when partially applied', () => {
-    const res = property()
+const actions = [
+  always(Promise.resolve({ foo: 1 })),
+  always(Promise.resolve({ bar: 2 })),
+]
 
-    beforeEach(() =>
-      combineAllP([
-        always(Promise.resolve({ foo: 1 })),
-        always(Promise.resolve({ bar: 2 })),
-      ])({ baz: 3 }).then(res)
-    )
+describe('combineAllP', () => {
+  it('combines the results of all functions', () =>
+    combineAllP(actions, { baz: 3 }).then(res => {
+      expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+    })
+  )
 
-    it('combines the results of all functions', () =>
-      expect(res()).to.eql({ foo: 1, bar: 2, baz: 3 })
-    )
-  })
-
-  context('when all arguments provided', () => {
-    const res = property()
-
-    beforeEach(() =>
-      combineAllP([
-        always(Promise.resolve({ foo: 1 })),
-        always(Promise.resolve({ bar: 2 })),
-      ], { baz: 3 }).then(res)
-    )
-
-    it('combines the results of all functions', () =>
-      expect(res()).to.eql({ foo: 1, bar: 2, baz: 3 })
-    )
-  })
+  it('is curried', () =>
+    combineAllP(actions)({ baz: 3 }).then(res => {
+      expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+    })
+  )
 })

--- a/test/combineP.js
+++ b/test/combineP.js
@@ -4,19 +4,36 @@ const always     = require('ramda/src/always')
 
 const { combineP } = require('..')
 
-const whatevs = combineP(always(Promise.resolve({ foo: 'bar' })))
+const combineFn = always(Promise.resolve({ foo: 'bar' }))
 
 describe('combine', () => {
-  const res = property()
+  context('when partially applied', () => {
+    const res = property()
 
-  beforeEach(() =>
-    whatevs({ baz: 'bip' }).then(res)
-  )
+    beforeEach(() =>
+      combineP(combineFn)({ baz: 'bip' }).then(res)
+    )
 
-  it('merges with the results of the function', () =>
-    expect(res()).to.eql({
-      foo: 'bar',
-      baz: 'bip',
-    })
-  )
+    it('merges with the results of the function', () =>
+      expect(res()).to.eql({
+        foo: 'bar',
+        baz: 'bip',
+      })
+    )
+  })
+
+  context('when all arguments provided', () => {
+    const res = property()
+
+    beforeEach(() =>
+      combineP(combineFn, { baz: 'bip' }).then(res)
+    )
+
+    it('merges with the results of the function', () =>
+      expect(res()).to.eql({
+        foo: 'bar',
+        baz: 'bip',
+      })
+    )
+  })
 })

--- a/test/combineP.js
+++ b/test/combineP.js
@@ -1,39 +1,26 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 const always     = require('ramda/src/always')
 
 const { combineP } = require('..')
 
 const combineFn = always(Promise.resolve({ foo: 'bar' }))
 
-describe('combine', () => {
-  context('when partially applied', () => {
-    const res = property()
-
-    beforeEach(() =>
-      combineP(combineFn)({ baz: 'bip' }).then(res)
-    )
-
-    it('merges with the results of the function', () =>
-      expect(res()).to.eql({
+describe('combineP', () => {
+  it('merges with the results of the function', () =>
+    combineP(combineFn, { baz: 'bip' }).then(res => {
+      expect(res).to.eql({
         foo: 'bar',
         baz: 'bip',
       })
-    )
-  })
+    })
+  )
 
-  context('when all arguments provided', () => {
-    const res = property()
-
-    beforeEach(() =>
-      combineP(combineFn, { baz: 'bip' }).then(res)
-    )
-
-    it('merges with the results of the function', () =>
-      expect(res()).to.eql({
+  it('is curried', () =>
+    combineP(combineFn)({ baz: 'bip' }).then(res => {
+      expect(res).to.eql({
         foo: 'bar',
         baz: 'bip',
       })
-    )
-  })
+    })
+  )
 })

--- a/test/combineWith.js
+++ b/test/combineWith.js
@@ -9,8 +9,13 @@ describe('combineWith', () => {
     expect(combineWith(multiply, add(2), 3)).to.eql(15)
   )
 
-  it('is curried', () => {
-    expect(combineWith(multiply, add(2))(3)).to.eql(15)
-    expect(combineWith(multiply)(add(2))(3)).to.eql(15)
+  describe('argument application', () => {
+    it('apply fn(x)(x)(x)', () =>
+      expect(combineWith(multiply)(add(2))(3)).to.eql(15)
+    )
+
+    it('apply fn(x, x)(x)', () =>
+      expect(combineWith(multiply, add(2))(3)).to.eql(15)
+    )
   })
 })

--- a/test/combineWith.js
+++ b/test/combineWith.js
@@ -5,19 +5,15 @@ const multiply   = require('ramda/src/multiply')
 const { combineWith } = require('..')
 
 describe('combineWith', () => {
-  context('when partially applied', () => {
-    it('combines with the results of the function', () =>
-      expect(
-        combineWith(multiply, add(2))(3)
-      ).to.eql(15)
-    )
-  })
+  it('combines with the results of the function', () =>
+    expect(
+      combineWith(multiply, add(2), 3)
+    ).to.eql(15)
+  )
 
-  context('when all arguments provided', () => {
-    it('combines with the results of the function', () =>
-      expect(
-        combineWith(multiply, add(2), 3)
-      ).to.eql(15)
-    )
-  })
+  it('is curried', () =>
+    expect(
+      combineWith(multiply, add(2))(3)
+    ).to.eql(15)
+  )
 })

--- a/test/combineWith.js
+++ b/test/combineWith.js
@@ -17,5 +17,9 @@ describe('combineWith', () => {
     it('apply fn(x, x)(x)', () =>
       expect(combineWith(multiply, add(2))(3)).to.eql(15)
     )
+
+    it('apply fn(x)(x, x)', () =>
+      expect(combineWith(multiply)(add(2), 3)).to.eql(15)
+    )
   })
 })

--- a/test/combineWith.js
+++ b/test/combineWith.js
@@ -6,14 +6,11 @@ const { combineWith } = require('..')
 
 describe('combineWith', () => {
   it('combines with the results of the function', () =>
-    expect(
-      combineWith(multiply, add(2), 3)
-    ).to.eql(15)
+    expect(combineWith(multiply, add(2), 3)).to.eql(15)
   )
 
-  it('is curried', () =>
-    expect(
-      combineWith(multiply, add(2))(3)
-    ).to.eql(15)
-  )
+  it('is curried', () => {
+    expect(combineWith(multiply, add(2))(3)).to.eql(15)
+    expect(combineWith(multiply)(add(2))(3)).to.eql(15)
+  })
 })

--- a/test/combineWith.js
+++ b/test/combineWith.js
@@ -1,20 +1,23 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 const add        = require('ramda/src/add')
 const multiply   = require('ramda/src/multiply')
 
 const { combineWith } = require('..')
 
-const whatevs = combineWith(multiply, add(2))
-
 describe('combineWith', () => {
-  const res = property()
+  context('when partially applied', () => {
+    it('combines with the results of the function', () =>
+      expect(
+        combineWith(multiply, add(2))(3)
+      ).to.eql(15)
+    )
+  })
 
-  beforeEach(() =>
-    res(whatevs(3))
-  )
-
-  it('combines with the results of the function', () =>
-    expect(res()).to.equal(15)
-  )
+  context('when all arguments provided', () => {
+    it('combines with the results of the function', () =>
+      expect(
+        combineWith(multiply, add(2), 3)
+      ).to.eql(15)
+    )
+  })
 })

--- a/test/combineWithP.js
+++ b/test/combineWithP.js
@@ -1,31 +1,30 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 
 const { add, mult }    = require('./lib/async')
 const { combineWithP } = require('..')
 
-describe('combineWith', () => {
-  context('when partially applied', () => {
-    const res = property()
+describe('combineWithP', () => {
+  it('combines with the results of the function', () =>
+    combineWithP(mult, add(2), 3).then(res => {
+      expect(res).to.equal(15)
+    })
+  )
 
-    beforeEach(() =>
-      combineWithP(mult, add(2))(3).then(res)
-    )
+  it('is curried, arity 1', () =>
+    combineWithP(mult, add(2))(3).then(res => {
+      expect(res).to.equal(15)
+    })
+  )
 
-    it('combines with the results of the function', () =>
-      expect(res()).to.equal(15)
-    )
-  })
+  it('is curried, arity 2', () =>
+    combineWithP(mult)(add(2), 3).then(res => {
+      expect(res).to.equal(15)
+    })
+  )
 
-  context('when all arguments provided', () => {
-    const res = property()
-
-    beforeEach(() =>
-      combineWithP(mult, add(2), 3).then(res)
-    )
-
-    it('combines with the results of the function', () =>
-      expect(res()).to.equal(15)
-    )
-  })
+  it('is curried, arity 2, unary', () =>
+    combineWithP(mult)(add(2))(3).then(res => {
+      expect(res).to.equal(15)
+    })
+  )
 })

--- a/test/combineWithP.js
+++ b/test/combineWithP.js
@@ -10,21 +10,23 @@ describe('combineWithP', () => {
     })
   )
 
-  it('is curried, arity 1', () =>
-    combineWithP(mult, add(2))(3).then(res => {
-      expect(res).to.equal(15)
-    })
-  )
+  describe('argument application', () => {
+    it('apply fn(x)(x)(x)', () =>
+      combineWithP(mult)(add(2))(3).then(res => {
+        expect(res).to.equal(15)
+      })
+    )
 
-  it('is curried, arity 2', () =>
-    combineWithP(mult)(add(2), 3).then(res => {
-      expect(res).to.equal(15)
-    })
-  )
+    it('apply fn(x)(x, x)', () =>
+      combineWithP(mult)(add(2), 3).then(res => {
+        expect(res).to.equal(15)
+      })
+    )
 
-  it('is curried, arity 2, unary', () =>
-    combineWithP(mult)(add(2))(3).then(res => {
-      expect(res).to.equal(15)
-    })
-  )
+    it('apply fn(x, x)(x)', () =>
+      combineWithP(mult, add(2))(3).then(res => {
+        expect(res).to.equal(15)
+      })
+    )
+  })
 })

--- a/test/combineWithP.js
+++ b/test/combineWithP.js
@@ -4,16 +4,28 @@ const property   = require('prop-factory')
 const { add, mult }    = require('./lib/async')
 const { combineWithP } = require('..')
 
-const whatevs = combineWithP(mult, add(2))
-
 describe('combineWith', () => {
-  const res = property()
+  context('when partially applied', () => {
+    const res = property()
 
-  beforeEach(() =>
-    whatevs(3).then(res)
-  )
+    beforeEach(() =>
+      combineWithP(mult, add(2))(3).then(res)
+    )
 
-  it('combines with the results of the function', () =>
-    expect(res()).to.equal(15)
-  )
+    it('combines with the results of the function', () =>
+      expect(res()).to.equal(15)
+    )
+  })
+
+  context('when all arguments provided', () => {
+    const res = property()
+
+    beforeEach(() =>
+      combineWithP(mult, add(2), 3).then(res)
+    )
+
+    it('combines with the results of the function', () =>
+      expect(res()).to.equal(15)
+    )
+  })
 })

--- a/test/convergeP.js
+++ b/test/convergeP.js
@@ -4,13 +4,11 @@ const property   = require('prop-factory')
 const { add, mult } = require('./lib/async')
 const { convergeP } = require('..')
 
-const whatevs = convergeP(mult, [ add(1), add(2) ])
-
 describe('convergeP', () => {
   const res = property()
 
   beforeEach(() =>
-    whatevs(1).then(res)
+    convergeP(mult, [ add(1), add(2) ])(1).then(res)
   )
 
   it('branches and converges with async functions', function () {

--- a/test/evolveP.js
+++ b/test/evolveP.js
@@ -4,16 +4,33 @@ const property   = require('prop-factory')
 const { add, mult } = require('./lib/async')
 const { evolveP }   = require('..')
 
-const evolutions = evolveP({ foo: add(2), bar: { baz: mult(3) } })
-
 describe('evolveP', () => {
-  const res = property()
+  context('when partially applied', () => {
+    const res = property()
 
-  beforeEach(() =>
-    evolutions({ foo: 1, bar: { baz: 1 }, bat: 1 }).then(res)
-  )
+    beforeEach(() =>
+      evolveP(
+        { foo: add(2), bar: { baz: mult(3) } }
+      )({ foo: 1, bar: { baz: 1 }, bat: 1 }).then(res)
+    )
 
-  it('recursively evolves an async shallow copy (??) of an object', () =>
-    expect(res()).to.eql({ foo: 3, bar: { baz: 3 }, bat: 1 })
-  )
+    it('recursively evolves an async shallow copy (??) of an object', () =>
+      expect(res()).to.eql({ foo: 3, bar: { baz: 3 }, bat: 1 })
+    )
+  })
+
+  context('when all arguments provided', () => {
+    const res = property()
+
+    beforeEach(() =>
+      evolveP(
+        { foo: add(2), bar: { baz: mult(3) } },
+        { foo: 1, bar: { baz: 1 }, bat: 1 }
+      ).then(res)
+    )
+
+    it('recursively evolves an async shallow copy (??) of an object', () =>
+      expect(res()).to.eql({ foo: 3, bar: { baz: 3 }, bat: 1 })
+    )
+  })
 })

--- a/test/evolveP.js
+++ b/test/evolveP.js
@@ -1,36 +1,21 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 
 const { add, mult } = require('./lib/async')
 const { evolveP }   = require('..')
 
+const arg1 = { foo: add(2), bar: { baz: mult(3) } }
+const arg2 = { foo: 1, bar: { baz: 1 }, bat: 1 }
+
 describe('evolveP', () => {
-  context('when partially applied', () => {
-    const res = property()
+  it('recursively evolves an async shallow copy (??) of an object', () =>
+    evolveP(arg1, arg2).then(res => {
+      expect(res).to.eql({ foo: 3, bar: { baz: 3 }, bat: 1 })
+    })
+  )
 
-    beforeEach(() =>
-      evolveP(
-        { foo: add(2), bar: { baz: mult(3) } }
-      )({ foo: 1, bar: { baz: 1 }, bat: 1 }).then(res)
-    )
-
-    it('recursively evolves an async shallow copy (??) of an object', () =>
-      expect(res()).to.eql({ foo: 3, bar: { baz: 3 }, bat: 1 })
-    )
-  })
-
-  context('when all arguments provided', () => {
-    const res = property()
-
-    beforeEach(() =>
-      evolveP(
-        { foo: add(2), bar: { baz: mult(3) } },
-        { foo: 1, bar: { baz: 1 }, bat: 1 }
-      ).then(res)
-    )
-
-    it('recursively evolves an async shallow copy (??) of an object', () =>
-      expect(res()).to.eql({ foo: 3, bar: { baz: 3 }, bat: 1 })
-    )
-  })
+  it('is curried', () =>
+    evolveP(arg1)(arg2).then(res => {
+      expect(res).to.eql({ foo: 3, bar: { baz: 3 }, bat: 1 })
+    })
+  )
 })

--- a/test/normalizeBy.js
+++ b/test/normalizeBy.js
@@ -9,25 +9,21 @@ const items = [
 ]
 
 describe('normalizeBy', () => {
-  context('when partially applied', () => {
-    it('normalizes a list by the specified key', () =>
-      expect(normalizeBy('id')(items))
-        .to.eql({
-          a: { id: 'a' },
-          b: { id: 'b' },
-          c: { id: 'c' }
-        })
-    )
-  })
+  it('normalizes a list by the specified key', () =>
+    expect(normalizeBy('id', items))
+      .to.eql({
+        a: { id: 'a' },
+        b: { id: 'b' },
+        c: { id: 'c' }
+      })
+  )
 
-  context('when all arguments provided', () => {
-    it('normalizes a list by the specified key', () =>
-      expect(normalizeBy('id', items))
-        .to.eql({
-          a: { id: 'a' },
-          b: { id: 'b' },
-          c: { id: 'c' }
-        })
-    )
-  })
+  it('is curried', () =>
+    expect(normalizeBy('id')(items))
+      .to.eql({
+        a: { id: 'a' },
+        b: { id: 'b' },
+        c: { id: 'c' }
+      })
+  )
 })

--- a/test/normalizeBy.js
+++ b/test/normalizeBy.js
@@ -9,12 +9,25 @@ const items = [
 ]
 
 describe('normalizeBy', () => {
-  it('normalizes a list by the specified key', () =>
-    expect(normalizeBy('id', items))
-      .to.eql({
-        a: { id: 'a' },
-        b: { id: 'b' },
-        c: { id: 'c' }
-      })
-  )
+  context('when partially applied', () => {
+    it('normalizes a list by the specified key', () =>
+      expect(normalizeBy('id')(items))
+        .to.eql({
+          a: { id: 'a' },
+          b: { id: 'b' },
+          c: { id: 'c' }
+        })
+    )
+  })
+
+  context('when all arguments provided', () => {
+    it('normalizes a list by the specified key', () =>
+      expect(normalizeBy('id', items))
+        .to.eql({
+          a: { id: 'a' },
+          b: { id: 'b' },
+          c: { id: 'c' }
+        })
+    )
+  })
 })

--- a/test/rename.js
+++ b/test/rename.js
@@ -3,27 +3,21 @@ const { expect } = require('chai')
 const { rename } = require('..')
 
 describe('rename', () => {
-  context('when partially applied', () => {
-    it('renames a property on an object to a different key', () =>
-      expect(rename('foo', 'baz')({ foo: 'bar' }))
-        .to.eql({ baz: 'bar' })
-    )
-
-    it('does not "rename" missing properties', () =>
-      expect(rename('foo', 'baz')({ not: 'bar' }))
-        .to.not.have.property('foo')
-    )
-  })
-
-  context('when all arguments provided', () => {
-    it('renames a property on an object to a different key', () =>
-      expect(rename('foo', 'baz', { foo: 'bar' }))
-        .to.eql({ baz: 'bar' })
-    )
-  })
+  it('renames a property on an object to a different key', () =>
+    expect(
+      rename('foo', 'baz', { foo: 'bar' })
+    ).to.eql({ baz: 'bar' })
+  )
 
   it('does not "rename" missing properties', () =>
-    expect(rename('foo', 'baz', { not: 'bar' }))
-      .to.not.have.property('foo')
+    expect(
+      rename('foo', 'baz', { not: 'bar' })
+    ).to.not.have.property('foo')
+  )
+
+  it('is curried', () =>
+    expect(
+      rename('foo', 'baz')({ foo: 'bar' })
+    ).to.eql({ baz: 'bar' })
   )
 })

--- a/test/rename.js
+++ b/test/rename.js
@@ -3,18 +3,27 @@ const { expect } = require('chai')
 const { rename } = require('..')
 
 describe('rename', () => {
-  it('renames a property on an object to a different key', () =>
-    expect(rename('foo', 'baz', { foo: 'bar' }))
-      .to.eql({ baz: 'bar' })
-  )
+  context('when partially applied', () => {
+    it('renames a property on an object to a different key', () =>
+      expect(rename('foo', 'baz')({ foo: 'bar' }))
+        .to.eql({ baz: 'bar' })
+    )
+
+    it('does not "rename" missing properties', () =>
+      expect(rename('foo', 'baz')({ not: 'bar' }))
+        .to.not.have.property('foo')
+    )
+  })
+
+  context('when all arguments provided', () => {
+    it('renames a property on an object to a different key', () =>
+      expect(rename('foo', 'baz', { foo: 'bar' }))
+        .to.eql({ baz: 'bar' })
+    )
+  })
 
   it('does not "rename" missing properties', () =>
     expect(rename('foo', 'baz', { not: 'bar' }))
       .to.not.have.property('foo')
-  )
-
-  it('is curried', () =>
-    expect(rename('foo', 'baz')({ foo: 'bar' }))
-      .to.eql({ baz: 'bar' })
   )
 })

--- a/test/rename.js
+++ b/test/rename.js
@@ -13,8 +13,8 @@ describe('rename', () => {
       .to.not.have.property('foo')
   )
 
-  it('is curried', () =>
-    expect(rename('foo', 'baz')({ foo: 'bar' }))
-      .to.eql({ baz: 'bar' })
-  )
+  it('is curried', () => {
+    expect(rename('foo', 'baz')({ foo: 'bar' })).to.eql({ baz: 'bar' })
+    expect(rename('foo')('baz')({ foo: 'bar' })).to.eql({ baz: 'bar' })
+  })
 })

--- a/test/rename.js
+++ b/test/rename.js
@@ -13,8 +13,17 @@ describe('rename', () => {
       .to.not.have.property('foo')
   )
 
-  it('is curried', () => {
-    expect(rename('foo', 'baz')({ foo: 'bar' })).to.eql({ baz: 'bar' })
-    expect(rename('foo')('baz')({ foo: 'bar' })).to.eql({ baz: 'bar' })
+  describe('argument application', () => {
+    it('apply fn(x)(x)(x)', () =>
+      expect(rename('foo')('baz')({ foo: 'bar' })).to.eql({ baz: 'bar' })
+    )
+
+    it('apply fn(x, x)(x)', () =>
+      expect(rename('foo', 'baz')({ foo: 'bar' })).to.eql({ baz: 'bar' })
+    )
+
+    it('apply fn(x)(x, x)', () =>
+      expect(rename('foo')('baz', { foo: 'bar' })).to.eql({ baz: 'bar' })
+    )
   })
 })

--- a/test/rename.js
+++ b/test/rename.js
@@ -4,20 +4,17 @@ const { rename } = require('..')
 
 describe('rename', () => {
   it('renames a property on an object to a different key', () =>
-    expect(
-      rename('foo', 'baz', { foo: 'bar' })
-    ).to.eql({ baz: 'bar' })
+    expect(rename('foo', 'baz', { foo: 'bar' }))
+      .to.eql({ baz: 'bar' })
   )
 
   it('does not "rename" missing properties', () =>
-    expect(
-      rename('foo', 'baz', { not: 'bar' })
-    ).to.not.have.property('foo')
+    expect(rename('foo', 'baz', { not: 'bar' }))
+      .to.not.have.property('foo')
   )
 
   it('is curried', () =>
-    expect(
-      rename('foo', 'baz')({ foo: 'bar' })
-    ).to.eql({ baz: 'bar' })
+    expect(rename('foo', 'baz')({ foo: 'bar' }))
+      .to.eql({ baz: 'bar' })
   )
 })

--- a/test/renameAll.js
+++ b/test/renameAll.js
@@ -27,13 +27,17 @@ describe('renameAll', () => {
     }
   }
 
-  it('rename multiple nested properties on an object using a name-map', () =>
-    expect(renameAll(renames, orig)).to.eql(expected)
-  )
+  context('when partially applied', () => {
+    it('renames multiple nested properties on an object using a name-map', () =>
+      expect(renameAll(renames)(orig)).to.eql(expected)
+    )
+  })
 
-  it('is curried', () =>
-    expect(renameAll(renames)(orig)).to.eql(expected)
-  )
+  context('when all arguments provided', () => {
+    it('renames multiple nested properties on an object using a name-map', () =>
+      expect(renameAll(renames, orig)).to.eql(expected)
+    )
+  })
 
   it('does not error in the pathological case', () =>
     expect(renameAll({}, orig)).to.eql(orig)

--- a/test/renameAll.js
+++ b/test/renameAll.js
@@ -31,11 +31,11 @@ describe('renameAll', () => {
     expect(renameAll(renames, orig)).to.eql(expected)
   )
 
-  it('does not error in the pathological case', () =>
-    expect(renameAll({}, orig)).to.eql(orig)
-  )
-
   it('is curried', () =>
     expect(renameAll(renames)(orig)).to.eql(expected)
+  )
+
+  it('does not error in the pathological case', () =>
+    expect(renameAll({}, orig)).to.eql(orig)
   )
 })

--- a/test/renameAll.js
+++ b/test/renameAll.js
@@ -27,19 +27,15 @@ describe('renameAll', () => {
     }
   }
 
-  context('when partially applied', () => {
-    it('renames multiple nested properties on an object using a name-map', () =>
-      expect(renameAll(renames)(orig)).to.eql(expected)
-    )
-  })
-
-  context('when all arguments provided', () => {
-    it('renames multiple nested properties on an object using a name-map', () =>
-      expect(renameAll(renames, orig)).to.eql(expected)
-    )
-  })
+  it('renames multiple nested properties on an object using a name-map', () =>
+    expect(renameAll(renames, orig)).to.eql(expected)
+  )
 
   it('does not error in the pathological case', () =>
     expect(renameAll({}, orig)).to.eql(orig)
+  )
+
+  it('is curried', () =>
+    expect(renameAll(renames)(orig)).to.eql(expected)
   )
 })

--- a/test/renamePath.js
+++ b/test/renamePath.js
@@ -6,17 +6,13 @@ describe('renamePath', () => {
   const orig     = { a: { b: 'b' }, c: 'c' }
   const expected = { a: { B: 'b' }, c: 'c' }
 
-  context('when partially applied', () => {
-    it('renames a deeply nested path on an object', () => {
-      expect(renamePath(['a', 'b'])('B', orig)).to.eql(expected)
-      expect(renamePath(['a', 'b'], 'B')(orig)).to.eql(expected)
-      expect(renamePath(['a', 'b'])('B')(orig)).to.eql(expected)
-    })
-  })
+  it('renames a deeply nested path on an object', () =>
+    expect(renamePath(['a', 'b'], 'B', orig)).to.eql(expected)
+  )
 
-  context('when all arguments provided', () => {
-    it('renames a deeply nested path on an object', () =>
-      expect(renamePath(['a', 'b'], 'B', orig)).to.eql(expected)
-    )
+  it('is curried', () => {
+    expect(renamePath(['a', 'b'])('B', orig)).to.eql(expected)
+    expect(renamePath(['a', 'b'], 'B')(orig)).to.eql(expected)
+    expect(renamePath(['a', 'b'])('B')(orig)).to.eql(expected)
   })
 })

--- a/test/renamePath.js
+++ b/test/renamePath.js
@@ -10,9 +10,17 @@ describe('renamePath', () => {
     expect(renamePath(['a', 'b'], 'B', orig)).to.eql(expected)
   )
 
-  it('is curried', () => {
-    expect(renamePath(['a', 'b'])('B', orig)).to.eql(expected)
-    expect(renamePath(['a', 'b'], 'B')(orig)).to.eql(expected)
-    expect(renamePath(['a', 'b'])('B')(orig)).to.eql(expected)
+  describe('argument application', () => {
+    it('apply fn(x)(x)(x)', () =>
+      expect(renamePath(['a', 'b'])('B')(orig)).to.eql(expected)
+    )
+
+    it('apply fn(x)(x, x)', () =>
+      expect(renamePath(['a', 'b'])('B', orig)).to.eql(expected)
+    )
+
+    it('apply fn(x, x)(x)', () =>
+      expect(renamePath(['a', 'b'], 'B')(orig)).to.eql(expected)
+    )
   })
 })

--- a/test/renamePath.js
+++ b/test/renamePath.js
@@ -6,13 +6,17 @@ describe('renamePath', () => {
   const orig     = { a: { b: 'b' }, c: 'c' }
   const expected = { a: { B: 'b' }, c: 'c' }
 
-  it('renames a deeply nested path on an object', () =>
-    expect(renamePath(['a', 'b'], 'B', orig)).to.eql(expected)
-  )
+  context('when partially applied', () => {
+    it('renames a deeply nested path on an object', () => {
+      expect(renamePath(['a', 'b'])('B', orig)).to.eql(expected)
+      expect(renamePath(['a', 'b'], 'B')(orig)).to.eql(expected)
+      expect(renamePath(['a', 'b'])('B')(orig)).to.eql(expected)
+    })
+  })
 
-  it('is curried', () => {
-    expect(renamePath(['a', 'b'])('B', orig)).to.eql(expected)
-    expect(renamePath(['a', 'b'], 'B')(orig)).to.eql(expected)
-    expect(renamePath(['a', 'b'])('B')(orig)).to.eql(expected)
+  context('when all arguments provided', () => {
+    it('renames a deeply nested path on an object', () =>
+      expect(renamePath(['a', 'b'], 'B', orig)).to.eql(expected)
+    )
   })
 })

--- a/test/useWithP.js
+++ b/test/useWithP.js
@@ -4,16 +4,14 @@ const property   = require('prop-factory')
 const { add, mult } = require('./lib/async')
 const { useWithP } = require('..')
 
-const whatevs = useWithP(mult, [ add(1), add(2) ])
-
 describe('useWithP', () => {
   const res = property()
 
   beforeEach(() =>
-    whatevs(3)(4).then(res)
+    useWithP(mult, [ add(1), add(2) ])(3)(4).then(res)
   )
 
-  it('transforms arguments with async functions', function () {
+  it('transforms arguments with async functions', () =>
     expect(res()).to.equal(24) // (3 + 1) * (4 + 2)
-  })
+  )
 })

--- a/test/useWithP.js
+++ b/test/useWithP.js
@@ -1,17 +1,18 @@
 const { expect } = require('chai')
-const property   = require('prop-factory')
 
 const { add, mult } = require('./lib/async')
 const { useWithP } = require('..')
 
 describe('useWithP', () => {
-  const res = property()
-
-  beforeEach(() =>
-    useWithP(mult, [ add(1), add(2) ])(3)(4).then(res)
+  it('transforms arguments with async functions', () =>
+    useWithP(mult, [ add(1), add(2) ])(3, 4).then(res => {
+      expect(res).to.equal(24) // (3 + 1) * (4 + 2)
+    })
   )
 
-  it('transforms arguments with async functions', () =>
-    expect(res()).to.equal(24) // (3 + 1) * (4 + 2)
+  it('is curried', () =>
+    useWithP(mult)([ add(1), add(2) ])(3)(4).then(res => {
+      expect(res).to.equal(24) // (3 + 1) * (4 + 2)
+    })
   )
 })


### PR DESCRIPTION
Closes #24 

## The Main Bits
* uses `uncurryN` where applicable
* ~uses `context`s in tests for (taste)testing the currying / partial application abilities~
* removes `whatevs` references to try to be consistently clear about what's happening