### PR TITLE
Fix Function Arities

### DIFF
--- a/src/combineAll.js
+++ b/src/combineAll.js
@@ -1,11 +1,11 @@
-const compose  = require('ramda/src/compose')
 const identity = require('ramda/src/identity')
 const juxt     = require('ramda/src/juxt')
 const mergeAll = require('ramda/src/mergeAll')
-const uncurryN = require('ramda/src/uncurryN')
+
+const doCombineAll = require('./lib/doCombineAll')
 
 // combineAll :: [({ k: v }, ...) -> { k: v }] -> ({ k: v }, ...) -> { k: v }
-const combineAll = fns =>
-  compose(mergeAll, juxt([ identity, ...fns ]))
+const combineAll = (fns, ...x) =>
+  mergeAll(juxt([ identity, ...fns ])(...x))
 
-module.exports = uncurryN(2, combineAll)
+module.exports = doCombineAll(combineAll)

--- a/src/combineAllP.js
+++ b/src/combineAllP.js
@@ -1,12 +1,11 @@
-const composeP = require('ramda/src/composeP')
 const identity = require('ramda/src/identity')
 const mergeAll = require('ramda/src/mergeAll')
-const uncurryN = require('ramda/src/uncurryN')
 
-const juxtP    = require('./juxtP')
+const doCombineAll = require('./lib/doCombineAll')
+const juxtP        = require('./juxtP')
 
 // combineAllP :: [({ k: v }, ...) -> Promise { k: v }] -> ({ k: v }, ...) -> Promise { k: v }
-const combineAllP = fns =>
-  composeP(mergeAll, juxtP([ identity, ...fns ]))
+const combineAllP = (fns, ...x) =>
+  juxtP([ identity, ...fns ])(...x).then(mergeAll)
 
-module.exports = uncurryN(2, combineAllP)
+module.exports = doCombineAll(combineAllP)

--- a/src/combineWith.js
+++ b/src/combineWith.js
@@ -1,9 +1,10 @@
 const converge = require('ramda/src/converge')
 const identity = require('ramda/src/identity')
-const uncurryN = require('ramda/src/uncurryN')
+
+const doCombine = require('./lib/doCombine')
 
 // combineWith :: (c -> b -> d) (a -> b) -> c -> d
-const combineWith = (mf, f) =>
-  converge(mf, [ identity, f ])
+const combineWith = (mf, f, ...x) =>
+  converge(mf, [ identity, f ])(...x)
 
-module.exports = uncurryN(3, combineWith)
+module.exports = doCombine(combineWith)

--- a/src/lib/curryMax.js
+++ b/src/lib/curryMax.js
@@ -1,13 +1,14 @@
 const curryN = require('ramda/src/curryN')
 
-const curryMax = (getLength, target, ...params) => {
-  const len = getLength(...params)
-  const fn = curryN(len + 1, target)
-  if (params.length === 1 && len === 0) {
+const curryMax = (n, getLength) =>
+  curryN(n + 1, (target, ...params) => {
+    const len = getLength(...params)
+    const fn = curryN(len + 1, target)
+    if (params.length === 1 && len === 0) {
     // explicity return a function with arity 0 that will spread args
-    return (...spread) => fn(...params, ...spread)
-  }
-  return fn(...params)
-}
+      return (...spread) => fn(...params, ...spread)
+    }
+    return fn(...params)
+  })
 
-module.exports = curryN(3, curryMax)
+module.exports = curryMax

--- a/src/lib/curryMax.js
+++ b/src/lib/curryMax.js
@@ -1,0 +1,13 @@
+const curryN = require('ramda/src/curryN')
+
+const curryMax = (getLength, target, ...params) => {
+  const len = getLength(...params)
+  const fn = curryN(len + 1, target)
+  if (params.length === 1 && len === 0) {
+    // explicity return a function with arity 0 that will spread args
+    return (...spread) => fn(...params, ...spread)
+  }
+  return fn(...params)
+}
+
+module.exports = curryN(3, curryMax)

--- a/src/lib/doAssemble.js
+++ b/src/lib/doAssemble.js
@@ -20,5 +20,5 @@ const getLength = cond([
   [ T,                    always(0)         ],
 ])
 
-const doAssemble = curryMax(getLength)
+const doAssemble = curryMax(1, getLength)
 module.exports = doAssemble

--- a/src/lib/doAssemble.js
+++ b/src/lib/doAssemble.js
@@ -1,12 +1,13 @@
 const always    = require('ramda/src/always')
 const cond      = require('ramda/src/cond')
 const curry     = require('ramda/src/curry')
-const curryN    = require('ramda/src/curryN')
 const length    = require('ramda/src/length')
 const map       = require('ramda/src/map')
 const T         = require('ramda/src/T')
 const transduce = require('ramda/src/transduce')
 const values    = require('ramda/src/values')
+
+const curryMax = require('./curryMax')
 
 const isTypeOf = curry((type, x) => typeof x === type)
 
@@ -19,17 +20,5 @@ const getLength = cond([
   [ T,                    always(0)         ],
 ])
 
-const doAssemble = (assemble, xfrms, ...x) => {
-  const len = getAssembleLength(xfrms)
-  const fn = curryN(len + 1, assemble)
-  if (x.length === 0) {
-    if (len === 0) {
-      // explicity return a function with arity 0 that will spread args
-      return (...y) => fn(xfrms, ...y)
-    }
-    return fn(xfrms)
-  }
-  return fn(xfrms, ...x)
-}
-
-module.exports = curry(doAssemble)
+const doAssemble = curryMax(getLength)
+module.exports = doAssemble

--- a/src/lib/doCombine.js
+++ b/src/lib/doCombine.js
@@ -1,0 +1,4 @@
+const curryMax = require('./curryMax')
+
+const doCombine = curryMax(2, (mf, f) => f.length)
+module.exports = doCombine

--- a/src/lib/doCombineAll.js
+++ b/src/lib/doCombineAll.js
@@ -1,5 +1,5 @@
 const curryMax = require('./curryMax')
 const maxArity = require('./maxArity')
 
-const doCombineAll = curryMax(maxArity)
+const doCombineAll = curryMax(1, maxArity)
 module.exports = doCombineAll

--- a/src/lib/doCombineAll.js
+++ b/src/lib/doCombineAll.js
@@ -1,0 +1,5 @@
+const curryMax = require('./curryMax')
+const maxArity = require('./maxArity')
+
+const doCombineAll = curryMax(maxArity)
+module.exports = doCombineAll

--- a/src/lib/maxArity.js
+++ b/src/lib/maxArity.js
@@ -1,0 +1,8 @@
+const transduce = require('ramda/src/transduce')
+const map       = require('ramda/src/map')
+const length    = require('ramda/src/length')
+
+const maxArity =
+  transduce(map(length), Math.max, 0)
+
+module.exports = maxArity

--- a/test/combineAll.js
+++ b/test/combineAll.js
@@ -1,21 +1,74 @@
 const { expect } = require('chai')
 const always     = require('ramda/src/always')
+const curryN     = require('ramda/src/curryN')
 
 const { combineAll } = require('..')
 
-const actions = [
-  always({ foo: 1 }),
-  always({ bar: 2 }),
-]
-
 describe('combineAll', () => {
-  it('combines the results of all functions', () =>
-    expect(combineAll(actions, { baz: 3 }))
-      .to.eql({ foo: 1, bar: 2, baz: 3 })
-  )
+  describe('unary', () => {
+    const actions = [
+      curryN(1, always({ foo: 1 })),
+      curryN(1, always({ bar: 2 })),
+    ]
 
-  it('is curried', () =>
-    expect(combineAll(actions)({ baz: 3 }))
-      .to.eql({ foo: 1, bar: 2, baz: 3 })
-  )
+    it('combines the results of all functions', () =>
+      expect(combineAll(actions, { baz: 3 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+
+    it('is curried', () =>
+      expect(combineAll(actions)({ baz: 3 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+
+    it('returns max function length', () => {
+      expect(combineAll(actions).length).to.equal(1)
+    })
+  })
+
+  describe('n-ary', () => {
+    const actions = [
+      curryN(2, always({ foo: 1 })),
+      curryN(3, always({ bar: 2 })),
+    ]
+
+    it('combines the results of all functions', () =>
+      expect(combineAll(actions, { baz: 3 }, { bop: 4 }, { boo: 5 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+
+    it('is curried', () => {
+      expect(combineAll(actions)({ baz: 3 }, { bop: 4 }, { boo: 5 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+      expect(combineAll(actions)({ baz: 3 })({ bop: 4 }, { boo: 5 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+      expect(combineAll(actions)({ baz: 3 })({ bop: 4 })({ boo: 5 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+    })
+
+    it('returns max function length', () => {
+      expect(combineAll(actions).length).to.equal(3)
+    })
+  })
+
+  describe('0-ary', () => {
+    const actions = [
+      always({ foo: 1 }),
+      always({ bar: 2 }),
+    ]
+
+    it('combines the results of all functions', () =>
+      expect(combineAll(actions, { baz: 3 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+
+    it('is curried', () =>
+      expect(combineAll(actions)({ baz: 3 }))
+        .to.eql({ foo: 1, bar: 2, baz: 3 })
+    )
+
+    it('returns max function length', () => {
+      expect(combineAll(actions).length).to.equal(0)
+    })
+  })
 })

--- a/test/combineAllP.js
+++ b/test/combineAllP.js
@@ -1,23 +1,79 @@
 const { expect } = require('chai')
 const always     = require('ramda/src/always')
+const curryN     = require('ramda/src/curryN')
 
 const { combineAllP } = require('..')
 
-const actions = [
-  always(Promise.resolve({ foo: 1 })),
-  always(Promise.resolve({ bar: 2 })),
-]
-
 describe('combineAllP', () => {
-  it('combines the results of all functions', () =>
-    combineAllP(actions, { baz: 3 }).then(res => {
-      expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
-    })
-  )
+  describe('unary', () => {
+    const actions = [
+      curryN(1, always(Promise.resolve({ foo: 1 }))),
+      curryN(1, always(Promise.resolve({ bar: 2 }))),
+    ]
 
-  it('is curried', () =>
-    combineAllP(actions)({ baz: 3 }).then(res => {
-      expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+    it('combines the results of all functions', () =>
+      combineAllP(actions, { baz: 3 }).then(res => {
+        expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+      })
+    )
+
+    it('is curried', () =>
+      combineAllP(actions)({ baz: 3 }).then(res => {
+        expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+      })
+    )
+
+    it('returns max function length', () => {
+      expect(combineAllP(actions).length).to.equal(1)
     })
-  )
+  })
+
+  describe('n-ary', () => {
+    const actions = [
+      curryN(2, always(Promise.resolve({ foo: 1 }))),
+      curryN(3, always(Promise.resolve({ bar: 2 }))),
+    ]
+
+    it('combines the results of all functions', () =>
+      combineAllP(actions, { baz: 3 }, { bop: 4 }, { boo: 5 }).then(res => {
+        expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+      })
+    )
+
+    it('is curried', () =>
+      combineAllP(actions)({ baz: 3 }, { bop: 4 }, { boo: 5 })
+        .then(res => { expect(res).to.eql({ foo: 1, bar: 2, baz: 3 }) })
+        .then(() => combineAllP(actions)({ baz: 3 })({ bop: 4 }, { boo: 5 }))
+        .then(res => { expect(res).to.eql({ foo: 1, bar: 2, baz: 3 }) })
+        .then(() => combineAllP(actions)({ baz: 3 })({ bop: 4 })({ boo: 5 }))
+        .then(res => { expect(res).to.eql({ foo: 1, bar: 2, baz: 3 }) })
+    )
+
+    it('returns max function length', () => {
+      expect(combineAllP(actions).length).to.equal(3)
+    })
+  })
+
+  describe('0-ary', () => {
+    const actions = [
+      always(Promise.resolve({ foo: 1 })),
+      always(Promise.resolve({ bar: 2 })),
+    ]
+
+    it('combines the results of all functions', () =>
+      combineAllP(actions, { baz: 3 }).then(res => {
+        expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+      })
+    )
+
+    it('is curried', () =>
+      combineAllP(actions)({ baz: 3 }).then(res => {
+        expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
+      })
+    )
+
+    it('returns max function length', () => {
+      expect(combineAllP(actions).length).to.equal(0)
+    })
+  })
 })

--- a/test/combineWith.js
+++ b/test/combineWith.js
@@ -5,21 +5,55 @@ const multiply   = require('ramda/src/multiply')
 const { combineWith } = require('..')
 
 describe('combineWith', () => {
-  it('combines with the results of the function', () =>
-    expect(combineWith(multiply, add(2), 3)).to.eql(15)
-  )
-
-  describe('argument application', () => {
-    it('apply fn(x)(x)(x)', () =>
-      expect(combineWith(multiply)(add(2))(3)).to.eql(15)
+  describe('unary', () => {
+    it('combines with the results of the function', () =>
+      expect(combineWith(multiply, add(2), 3)).to.eql(15)
     )
 
-    it('apply fn(x, x)(x)', () =>
-      expect(combineWith(multiply, add(2))(3)).to.eql(15)
+    it('has correct length', () => {
+      expect(combineWith(multiply, add(2)).length).to.equal(1)
+    })
+
+    describe('argument application', () => {
+      it('apply fn(x)(x)(x)', () =>
+        expect(combineWith(multiply)(add(2))(3)).to.eql(15)
+      )
+
+      it('apply fn(x, x)(x)', () =>
+        expect(combineWith(multiply, add(2))(3)).to.eql(15)
+      )
+
+      it('apply fn(x)(x, x)', () =>
+        expect(combineWith(multiply)(add(2), 3)).to.eql(15)
+      )
+    })
+  })
+
+  describe('n-ary', () => {
+    it('combines with the results of the function', () =>
+      expect(combineWith(multiply, add, 3, 2)).to.eql(15)
     )
 
-    it('apply fn(x)(x, x)', () =>
-      expect(combineWith(multiply)(add(2), 3)).to.eql(15)
-    )
+    it('has correct length', () => {
+      expect(combineWith(multiply, add).length).to.equal(2)
+    })
+
+    describe('argument application', () => {
+      it('apply fn(x)(x)(x)(x)', () =>
+        expect(combineWith(multiply)(add)(3)(2)).to.eql(15)
+      )
+
+      it('apply fn(x, x)(x)(x)', () =>
+        expect(combineWith(multiply, add)(3)(2)).to.eql(15)
+      )
+
+      it('apply fn(x)(x, x)(x)', () =>
+        expect(combineWith(multiply)(add, 3)(2)).to.eql(15)
+      )
+
+      it('apply fn(x)(x)(x, x)', () =>
+        expect(combineWith(multiply)(add)(2, 3)).to.eql(15)
+      )
+    })
   })
 })


### PR DESCRIPTION
Closes https://github.com/articulate/funky/issues/34

Open draft to attempt to magically fix function arities. We already have this working for `assemble`, but expanding this solution to `combine(P)`, `combineWith(P)`, & `combineAll(P)` is proving to be troublesome.