### PR TITLE
When result-matching, cache promises by the inputKey

### DIFF
--- a/src/batch.js
+++ b/src/batch.js
@@ -27,8 +27,10 @@ const batch = (opts={}, f) => {
     matching ? (resolves[inputKey(arg)] = res) : resolves.push(res)
 
   const batched = arg => {
-    if (uniq.has(arg)) {
-      return uniq.get(arg)
+    const cacheKey = matching ? inputKey(arg) : arg
+
+    if (uniq.has(cacheKey)) {
+      return uniq.get(cacheKey)
     } else {
       const promise = new Promise((res, rej) => {
         args.push(arg)
@@ -36,7 +38,7 @@ const batch = (opts={}, f) => {
         addResolve(arg, res)
       })
 
-      uniq.set(arg, promise)
+      uniq.set(cacheKey, promise)
 
       if (args.length >= limit) run()
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const property   = require('prop-factory')
 const Spy        = require('@articulate/spy')
 
-const { prop } = require('ramda')
+const { identity, prop } = require('ramda')
 
 const { batch, evolveP, mapP } = require('..')
 
@@ -112,6 +112,33 @@ describe('batch', () => {
   })
 
   describe('with matching enabled', () => {
+    const asyncListFn = () =>
+      (spy(), Promise.resolve([{ id: 'c' }, { id: 'b' }]))
+
+    const batched =
+      batch({ inputKey: identity, outputKey: prop('id') }, asyncListFn)
+
+    const test = evolveP({
+      a: batched,
+      b: batched,
+      c: batched
+    })
+
+    beforeEach(() =>
+      test(obj).then(res)
+    )
+
+    it('matches each result to the original input', () => {
+      expect(spy.calls.length).to.equal(1)
+      expect(res()).to.eql({
+        a: undefined,
+        b: { id: 'b' },
+        c: { id: 'c' }
+      })
+    })
+  })
+
+  describe('with matching enabled and duplicate inputs', () => {
     const input = [
       { id: 'a' },
       { id: 'b' },

--- a/test/batch.js
+++ b/test/batch.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const property   = require('prop-factory')
 const Spy        = require('@articulate/spy')
 
-const { identity, prop } = require('ramda')
+const { prop } = require('ramda')
 
 const { batch, evolveP, mapP } = require('..')
 


### PR DESCRIPTION
![dilbert](https://assets.amuniversal.com/a3042a406d5901301d7d001dd8b71c47)

Currently, different arguments with the same `inputKey` result cause batched functions to hang indefinitely, since only the last matching Promise will be resolved.  This PR solves that.

This is really how we should have been doing it since we introduced result-matching, because it's the `inputKey` that matters when comparing arguments, not the arguments themselves.  I'm more surprised that it hasn't bitten us until now.

## to review
- [ ] Check the code.
- [ ] Wait for the green.
- [ ] Find a matching squirrel.