### PR TITLE
Change: address #34 by updating combine*'s API

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,8 +13,8 @@
 | [`combineAll`](#combineall) | `[({ k: v }, ...) -> { k: v }] -> ({ k: v }, ...) -> { k: v }` |
 | [`combineAllP`](#combineallp) | `[({ k: v }, ...) -> Promise { k: v }] -> ({ k: v }, ...) -> Promise { k: v }` |
 | [`combineP`](#combinep) | `({ k: v } -> Promise { k: v }) -> { k: v } -> Promise { k: v }` |
-| [`combineWith`](#combinewith) | `(c -> b -> d) (a -> b) -> c -> d` |
-| [`combineWithP`](#combinewithp) | `(c -> b -> d) (a -> Promise b) -> Promise c -> Promise d` |
+| [`combineWith`](#combinewith) | `(c -> b -> d) -> (a -> b) -> c -> d` |
+| [`combineWithP`](#combinewithp) | `(c -> b -> d) -> (a -> Promise b) -> Promise c -> Promise d` |
 | [`convergeP`](#convergep) | `(b -> c -> Promise d) -> [(a -> Promise b), (a -> Promise c)] -> a -> Promise d` |
 | [`copyProp`](#copyprop) | `String -> String -> { k: v } -> { k: v }` |
 | [`copyPath`](#copypath) | `[String] -> [String] -> { k: v } -> { k: v }` |
@@ -196,13 +196,13 @@ const getSub =
 `@articulate/funky/lib/combine`
 
 ```haskell
-combine :: ({ k: v } -> { k: v }) -> { k: v }
+combine :: ({ k: v } -> { k: v }) -> { k: v } -> { k: v }
 ```
 
 Accepts a function & an object. Merges the results of the function into the object.
 
 ```js
-combine(always({ foo: 1 }), { foo: 2, bar: 3 }) //=> { foo: 1, baz: 3 }
+combine(always({ foo: 1 }))({ foo: 2, bar: 3 }) //=> { foo: 1, baz: 3 }
 ```
 
 ### combineAll
@@ -210,13 +210,13 @@ combine(always({ foo: 1 }), { foo: 2, bar: 3 }) //=> { foo: 1, baz: 3 }
 `@articulate/funky/lib/combineAll`
 
 ```haskell
-combineAll :: [a... -> { k: v }] -> { k: v } -> { k: v }
+combineAll :: [({ k: v }, ...) -> { k: v }] -> ({ k: v }, ...) -> { k: v }
 ```
 
 Accepts a list of functions & an object. Merges the results of all the functions into the object left-to-right
 
 ```js
-combineAll([ always({ foo: 1, bar: 2 }), always({ bar: 3 }) ], { foo: 4, baz: 5 }) //=> { foo: 1, bar: 3, baz: 5 }
+combineAll([ always({ foo: 1, bar: 2 }), always({ bar: 3 }) ])({ foo: 4, baz: 5 }) //=> { foo: 1, bar: 3, baz: 5 }
 ```
 
 ### combineAllP
@@ -233,7 +233,7 @@ Async version of [`combineAll`](#combineall)
 combineAllP([
   always(resolve({ foo: 1, bar: 2 })),
   always(resolve({ bar: 3 }))
-], { foo: 4, baz: 5 }) //=> Promise { foo: 1, baz: 5, bar: 3 }
+])({ foo: 4, baz: 5 }) //=> Promise { foo: 1, baz: 5, bar: 3 }
 ```
 
 ### combineP
@@ -241,7 +241,7 @@ combineAllP([
 `@articulate/funky/lib/combineP`
 
 ```haskell
-combineP :: ({ k: v } -> Promise { k: v }) -> Promise { k: v }
+combineP :: ({ k: v } -> Promise { k: v }) -> { k: v } -> Promise { k: v }
 ```
 
 Async version of [`combine`](#combine)
@@ -249,7 +249,7 @@ Async version of [`combine`](#combine)
 Accepts an async function & an object. Merges the results of the function into the object.
 
 ```js
-combineP(always(resolve({ foo: 1 })), { foo: 2, bar: 3 }) //=> Promise { foo: 1, baz: 3 }
+combineP(always(resolve({ foo: 1 })))({ foo: 2, bar: 3 }) //=> Promise { foo: 1, baz: 3 }
 ```
 
 ### combineWith
@@ -257,14 +257,14 @@ combineP(always(resolve({ foo: 1 })), { foo: 2, bar: 3 }) //=> Promise { foo: 1,
 `@articulate/funky/lib/combineWith`
 
 ```haskell
-combineWith :: (c -> b -> d) (a -> b) -> c -> d
+combineWith :: (c -> b -> d) -> (a -> b) -> c -> d
 ```
 
 Accepts a merging function, a transformation function, and an value. Uses the merging function to merge the results of the transformation function into the value.
 
 ```js
 combineWith(multiply, add(2), 3) //=> 15
-combineWith(mergeDeepLeft, always({ foo: { bar: 1, bip: 2 } }), { foo: { bar: 3, baz: 4 } })
+combineWith(mergeDeepLeft, always({ foo: { bar: 1, bip: 2 } }))({ foo: { bar: 3, baz: 4 } })
   //=> { foo: { bar: 3, baz: 4, bip: 2 } }
 ```
 
@@ -273,7 +273,7 @@ combineWith(mergeDeepLeft, always({ foo: { bar: 1, bip: 2 } }), { foo: { bar: 3,
 `@articulate/funky/lib/combineWithP`
 
 ```haskell
-combineWithP :: (c -> b -> d) (a -> Promise b) -> Promise c -> Promise d
+combineWithP :: (c -> b -> d) -> (a -> Promise b) -> Promise c -> Promise d
 ```
 
 Async version of [`combineWith`](#combinewith).
@@ -282,7 +282,7 @@ Accepts a merging function, an async transformation function, and an value. Uses
 
 ```js
 combineWith(multiply, compose(resolve, add(2)), 3) //=> Promise 15
-combineWith(mergeDeepLeft, always(resolve({ foo: { bar: 1, bip: 2 } })), { foo: { bar: 3, baz: 4 } })
+combineWith(mergeDeepLeft, always(resolve({ foo: { bar: 1, bip: 2 } })))({ foo: { bar: 3, baz: 4 } })
   //=> Promise { foo: { bar: 3, baz: 4, bip: 2 } }
 ```
 

--- a/src/combineAll.js
+++ b/src/combineAll.js
@@ -2,10 +2,9 @@ const compose  = require('ramda/src/compose')
 const identity = require('ramda/src/identity')
 const juxt     = require('ramda/src/juxt')
 const mergeAll = require('ramda/src/mergeAll')
-const uncurryN = require('ramda/src/uncurryN')
 
 // combineAll :: [({ k: v }, ...) -> { k: v }] -> ({ k: v }, ...) -> { k: v }
 const combineAll = fns =>
   compose(mergeAll, juxt([ identity, ...fns ]))
 
-module.exports = uncurryN(2, combineAll)
+module.exports = combineAll

--- a/src/combineAllP.js
+++ b/src/combineAllP.js
@@ -1,7 +1,6 @@
 const composeP = require('ramda/src/composeP')
 const identity = require('ramda/src/identity')
 const mergeAll = require('ramda/src/mergeAll')
-const uncurryN = require('ramda/src/uncurryN')
 
 const juxtP    = require('./juxtP')
 
@@ -9,4 +8,4 @@ const juxtP    = require('./juxtP')
 const combineAllP = fns =>
   composeP(mergeAll, juxtP([ identity, ...fns ]))
 
-module.exports = uncurryN(2, combineAllP)
+module.exports = combineAllP

--- a/src/combineWith.js
+++ b/src/combineWith.js
@@ -1,9 +1,10 @@
 const converge = require('ramda/src/converge')
+const curryN   = require('ramda/src/curryN')
 const identity = require('ramda/src/identity')
-const uncurryN = require('ramda/src/uncurryN')
 
-// combineWith :: (c -> b -> d) (a -> b) -> c -> d
-const combineWith = (mf, f) =>
+// combineWith :: (c -> b -> d) -> (a -> b) -> c -> d
+const combineWith = curryN(2, (mf, f) =>
   converge(mf, [ identity, f ])
+)
 
-module.exports = uncurryN(3, combineWith)
+module.exports = combineWith

--- a/src/combineWithP.js
+++ b/src/combineWithP.js
@@ -1,10 +1,11 @@
+const curryN   = require('ramda/src/curryN')
 const identity = require('ramda/src/identity')
-const uncurryN = require('ramda/src/uncurryN')
 
 const convergeP = require('./convergeP')
 
-// combineWithP :: (c -> b -> d) (a -> Promise b) -> Promise c -> Promise d
-const combineWithP = (mf, f) =>
+// combineWithP :: (c -> b -> d) -> (a -> Promise b) -> Promise c -> Promise d
+const combineWithP = curryN(2, (mf, f) =>
   convergeP(mf, [ identity, f ])
+)
 
-module.exports = uncurryN(3, combineWithP)
+module.exports = combineWithP

--- a/test/combine.js
+++ b/test/combine.js
@@ -5,11 +5,6 @@ const { combine } = require('..')
 
 describe('combine', () => {
   it('merges with the results of the function', () =>
-    expect(combine(always({ foo: 'bar' }), { baz: 'bip' }))
-      .to.eql({ foo: 'bar', baz: 'bip' })
-  )
-
-  it('is curried', () =>
     expect(combine(always({ foo: 'bar' }))({ baz: 'bip' }))
       .to.eql({ foo: 'bar', baz: 'bip' })
   )

--- a/test/combineAll.js
+++ b/test/combineAll.js
@@ -10,11 +10,6 @@ const actions = [
 
 describe('combineAll', () => {
   it('combines the results of all functions', () =>
-    expect(combineAll(actions, { baz: 3 }))
-      .to.eql({ foo: 1, bar: 2, baz: 3 })
-  )
-
-  it('is curried', () =>
     expect(combineAll(actions)({ baz: 3 }))
       .to.eql({ foo: 1, bar: 2, baz: 3 })
   )

--- a/test/combineAllP.js
+++ b/test/combineAllP.js
@@ -10,12 +10,6 @@ const actions = [
 
 describe('combineAllP', () => {
   it('combines the results of all functions', () =>
-    combineAllP(actions, { baz: 3 }).then(res => {
-      expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
-    })
-  )
-
-  it('is curried', () =>
     combineAllP(actions)({ baz: 3 }).then(res => {
       expect(res).to.eql({ foo: 1, bar: 2, baz: 3 })
     })

--- a/test/combineP.js
+++ b/test/combineP.js
@@ -7,15 +7,6 @@ const combineFn = always(Promise.resolve({ foo: 'bar' }))
 
 describe('combineP', () => {
   it('merges with the results of the function', () =>
-    combineP(combineFn, { baz: 'bip' }).then(res => {
-      expect(res).to.eql({
-        foo: 'bar',
-        baz: 'bip',
-      })
-    })
-  )
-
-  it('is curried', () =>
     combineP(combineFn)({ baz: 'bip' }).then(res => {
       expect(res).to.eql({
         foo: 'bar',

--- a/test/combineWith.js
+++ b/test/combineWith.js
@@ -6,20 +6,12 @@ const { combineWith } = require('..')
 
 describe('combineWith', () => {
   it('combines with the results of the function', () =>
-    expect(combineWith(multiply, add(2), 3)).to.eql(15)
+    expect(combineWith(multiply, add(2))(3)).to.eql(15)
   )
 
   describe('argument application', () => {
     it('apply fn(x)(x)(x)', () =>
       expect(combineWith(multiply)(add(2))(3)).to.eql(15)
-    )
-
-    it('apply fn(x, x)(x)', () =>
-      expect(combineWith(multiply, add(2))(3)).to.eql(15)
-    )
-
-    it('apply fn(x)(x, x)', () =>
-      expect(combineWith(multiply)(add(2), 3)).to.eql(15)
     )
   })
 })

--- a/test/combineWithP.js
+++ b/test/combineWithP.js
@@ -5,7 +5,7 @@ const { combineWithP } = require('..')
 
 describe('combineWithP', () => {
   it('combines with the results of the function', () =>
-    combineWithP(mult, add(2), 3).then(res => {
+    combineWithP(mult, add(2))(3).then(res => {
       expect(res).to.equal(15)
     })
   )
@@ -13,18 +13,6 @@ describe('combineWithP', () => {
   describe('argument application', () => {
     it('apply fn(x)(x)(x)', () =>
       combineWithP(mult)(add(2))(3).then(res => {
-        expect(res).to.equal(15)
-      })
-    )
-
-    it('apply fn(x)(x, x)', () =>
-      combineWithP(mult)(add(2), 3).then(res => {
-        expect(res).to.equal(15)
-      })
-    )
-
-    it('apply fn(x, x)(x)', () =>
-      combineWithP(mult, add(2))(3).then(res => {
         expect(res).to.equal(15)
       })
     )


### PR DESCRIPTION
Closes https://github.com/articulate/funky/issues/34 by addressing the issue there for all `combine*` functions.

The tl;dr is that the data needs to be sent, by itself, as the last function call, similarly to how `converge` and `juxt` work in ramda.

You can call `combineWith` and `combineWithP` like `(f)(g)(a)` or `(f, g)(a)`, but _not_ `(f, g, a)` _nor_ `(f)(g, a)`.

IMO, this constitutes a breaking change and is a major version bump unless y'all can somehow justify it as a bug fix.

Let me know what y'all think and what changes you want to see!