### PR TITLE
Upgrade `ramda` to `v0.27.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "mocha test --reporter=dot"
   },
   "dependencies": {
-    "ramda": "^0.25.0"
+    "ramda": "0.27.2"
   },
   "devDependencies": {
     "@articulate/spy": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,10 +1821,10 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
+ramda@0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
+  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
 
 randomatic@^1.1.3:
   version "1.1.7"


### PR DESCRIPTION
We need to upgrade `ramda` in `revocal`, and its two dependencies `funky` and `authentic`, as part of a security alert from Snyk (linked in the issue below).  We need to ugrade to version `0.27.2` or higher for `ramda`.  We can't use `0.28.0` in `funky` yet because we still depend on the `composeP` function (among some others) that were removed from version `0.28.0` of `ramda`.

Issue: https://github.com/articulate/identity/issues/925