### PR TITLE
v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/funky",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Functional helper library",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Bumping the version to `v2.0.1` myself since yarn was having trouble with this using `yarn publish`.  The package has already been pushed to npm as version `2.0.1`.

```
stephenpurr@Stephens-MacBook-Pro funky % yarn publish
yarn publish v1.22.17
[1/4] Bumping version...
info Current version: 2.0.0
question New version: 2.0.1
$ git checkout master && yarn run build
error: pathspec 'master' did not match any file(s) known to git
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/publish for documentation about this command.
```